### PR TITLE
checklist: Add "Flashing Beacon" to "Starting Engine" (fixes #2)

### DIFF
--- a/c172-checklists.xml
+++ b/c172-checklists.xml
@@ -110,6 +110,24 @@
   <checklist>
     <title>Starting Engine</title>
     <item>
+      <name>Flashing Beacon</name>
+      <value>ON</value>
+      <marker>
+        <x-m>-0.3608</x-m>
+        <y-m>-0.1550</y-m>
+        <z-m>-0.2633</z-m>
+        <scale>1.7167</scale>
+      </marker>
+      <condition>
+        <property>/controls/lighting/beacon</property>
+      </condition>
+      <binding>
+        <command>property-assign</command>
+        <property>/controls/lighting/beacon</property>
+        <value type="bool">true</value>
+      </binding>
+    </item>
+    <item>
       <name>Prime</name>
       <value>As Required - 2-6 strokes</value>
       <marker>


### PR DESCRIPTION
Fixes #2.