### PR TITLE
Fix #103 by forcing initialization of lighting state properties

### DIFF
--- a/Nasal/electrical.nas
+++ b/Nasal/electrical.nas
@@ -49,6 +49,13 @@ init_electrical = func {
     props.globals.getNode("controls/circuit-breakers/radio5", 1).setBoolValue(1);
     props.globals.getNode("controls/circuit-breakers/autopilot", 1).setBoolValue(1);
 
+    # These two properties are aliased to MP properties in /sim/multiplay/generic/.
+    # This aliasing seems to work in both ways, because the two properties below
+    # appear to receive the random values from the MP properties during initialization.
+    # Therefore, override these random values with the proper values we want.
+    props.globals.getNode("sim/model/c172p/lighting/beacon-top/state", 0).setBoolValue(0);
+    props.globals.getNode("sim/model/c172p/lighting/strobes/state", 0).setBoolValue(0);
+
     # Request that the update function be called next frame
     settimer(update_electrical, 0);
     print("Electrical system initialized");


### PR DESCRIPTION
Should fix #103. Please do `git checkout bug-103` to test this locally before giving a :+1:.