### PR TITLE
Only show ALS lights if in internal view and master is on

### DIFF
--- a/Models/c172p-detailed.xml
+++ b/Models/c172p-detailed.xml
@@ -1947,14 +1947,7 @@
       <label>Landing Lights: %s</label>
       <mapping>on-off</mapping>
       <property>controls/lighting/landing-lights</property>
-   </binding>
-     <!-- MOD: Clone from GIT to v3.2 -->
-     <binding>
-       <command>property-assign</command>
-       <property>sim/rendering/als-secondary-lights/use-landing-light</property>
-       <property>controls/lighting/landing-lights</property>
-     </binding>
-     <!-- MODEND: Clone from GIT to v3.2 -->
+    </binding>
    </hovered>
  </animation>
 

--- a/Systems/als-lights.xml
+++ b/Systems/als-lights.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright (c) 2015 onox
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<PropertyList>
+
+    <logic>
+        <name>ALS Lighting Landing</name>
+        <input>
+            <and>
+                <property>/sim/current-view/internal</property>
+                <less-than>
+                    <property>/systems/electrical/outputs/landing-lights</property>
+                    <value>28.0</value>
+                </less-than>
+                <greater-than>
+                    <property>/systems/electrical/outputs/landing-lights</property>
+                    <value>20.0</value>
+                </greater-than>
+            </and>
+        </input>
+        <output>
+            <property>/sim/rendering/als-secondary-lights/use-landing-light</property>
+        </output>
+    </logic>
+
+    <logic>
+        <name>ALS Lighting Taxi</name>
+        <input>
+            <and>
+                <property>/sim/current-view/internal</property>
+                <less-than>
+                    <property>/systems/electrical/outputs/taxi-light</property>
+                    <value>28.0</value>
+                </less-than>
+                <greater-than>
+                    <property>/systems/electrical/outputs/taxi-light</property>
+                    <value>20.0</value>
+                </greater-than>
+            </and>
+        </input>
+        <output>
+            <property>/sim/rendering/als-secondary-lights/use-alt-landing-light</property>
+        </output>
+    </logic>
+
+</PropertyList>

--- a/c172p-detailed-set.xml
+++ b/c172p-detailed-set.xml
@@ -157,6 +157,10 @@ Many files from the original c172p directory are included in this file.
     <property-rule n="101">
       <path>Aircraft/c172p-detailed/Systems/gearAGL.xml</path>
     </property-rule>
+
+    <property-rule n="102">
+      <path>Aircraft/c172p-detailed/Systems/als-lights.xml</path>
+    </property-rule>
   </systems>
 
   <sound>


### PR DESCRIPTION
Fixes #77 

I have wired the taxi light to the alternate ALS light, so you can have two ALS lights if you enable taxi and landing lights.