### PR TITLE
dialogs: Clean up "Aircraft Options" and "Registration"

### DIFF
--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -13,300 +13,230 @@
 -->
 
 <PropertyList>
-	<name>aircraft-dialog</name>
-	<layout>vbox</layout>
-	<resizable>false</resizable>
-	<modal>false</modal>
-	<draggable>true</draggable>
-	<default-padding>3</default-padding>
 
-	<nasal>
-		<open>
-			var init = func {
-			
-				#bush kit
-				var p = getprop("fdm/jsbsim/bushkit");
-				setprop("/sim/model/c172p/bushkit_flag_0",0);
-				setprop("/sim/model/ec130/bushkit_flag_1",0);
-				setprop("/sim/model/ec130/bushkit_flag_2",0);
-				if ( p == 0 ) { setprop("/sim/model/c172p/bushkit_flag_0",1); }
-				if ( p == 1 ) { setprop("/sim/model/c172p/bushkit_flag_1",1); }
-				if ( p == 2 ) { setprop("/sim/model/c172p/bushkit_flag_2",1); }
-				
-				#shadow volume
-				var p = getprop("/sim/rendering/shadow-volume");
-				if (p) {
-					if (!c172p.check_eligibility()) {
-						setprop("/sim/rendering/shadow-volume", 0);
-					}
-				}
-	
-			}
+    <name>aircraft-dialog</name>
+    <layout>vbox</layout>
+    <resizable>false</resizable>
+    <modal>false</modal>
+    <draggable>true</draggable>
 
-			#if {getprop("/fdm/jsbsim/running")) {
-			#	c172p.autostart();
-			#	setprop("/controls/switches/starter", 3);
-			#}
-	
-			init();
-		</open>
-	</nasal>
-	
-	<group>	
-		<layout>hbox</layout>
-		<default-padding>5</default-padding>
-		<empty><stretch>1</stretch></empty>
-		<text>
-			<label>Aircraft Options</label>
-		</text>
-		<empty><stretch>true</stretch></empty>
-		<button>
-			<legend></legend>
-			<key>Esc</key>
-			<pref-width>16</pref-width>
-			<pref-height>16</pref-height>
-			<binding>
-				<command>dialog-close</command>
-			</binding>
-		</button>
-	</group>
-	
-	<hrule/>
-	
-	<group>
-		<layout>hbox</layout>
-		<default-padding>5</default-padding>
-	</group>
-	
-	<group>
-		<layout>hbox</layout>
-		<default-padding>5</default-padding>
-		<empty><stretch>1</stretch></empty>
-		<halign>left</halign>
-		<checkbox>
-			<label> Start with engine running</label>
-			<property>/fdm/jsbsim/running</property>
-			<live>true</live>
-			<binding>
-				<command>dialog-apply</command>
-			</binding>
-		</checkbox>
-	</group>
-	
-	<group>
-		<layout>hbox</layout>
-		<default-padding>5</default-padding>
-		<empty><stretch>1</stretch></empty>
-		<halign>left</halign>
-		<checkbox>
-			<label> Complex start up procedures</label>
-			<property>/fdm/jsbsim/complex</property>
-			<live>true</live>
-			<binding>
-				<command>dialog-apply</command>
-			</binding>
-		</checkbox>
-	</group>
-	
-	<text>  
-        <label>--------------------------</label>
-        <halign>center</halign>
-    </text>
-	
-	<group>
-		<layout>table</layout>
-		<default-padding>5</default-padding>
-		<halign>left</halign>
-		
-		<text>
-			<row>0</row>
-			<col>0</col>
-			<label> </label>
-			<halign>left</halign>
-         </text>
-		 	
-		<checkbox>
-			<row>0</row>
-			<col>1</col>
-			<label> Damage</label>
-			<property>/fdm/jsbsim/damage</property>
-			<live>true</live>
-			<binding>
-				<command>dialog-apply</command>
-			</binding>
-		</checkbox>
-		
-		<text>
-           <row>0</row>
-           <col>2</col>
-           <label>     </label>
-           <halign>left</halign>
-         </text>
-		 
-		<button>
-           <row>0</row>
-           <col>3</col>
-			<legend> Repair </legend>
-			<pref-width>60</pref-width>
-			<pref-height>28</pref-height>
-			<binding>
-				<command>nasal</command>
-				<script>c172p.resetalldamage()</script>
-			</binding>
-		</button>
-	</group>
-	
-	<text>  
-        <label>--------------------------</label>
-        <halign>center</halign>
-    </text>
-	
-	<group>
-		<layout>hbox</layout>
-		<default-padding>5</default-padding>
-		<empty><stretch>1</stretch></empty>
-		<halign>left</halign>
-		<checkbox>
-			<label> Shadow Volume</label>
-			<property>/sim/rendering/shadow-volume</property>
-			<live>true</live>
-			<binding>
-				<command>nasal</command>
-				<script>c172p.toggle_shadow_volume()</script>
-			</binding>
-		</checkbox>
-	</group>
-	
-	<text>  
-        <label>--------------------------</label>
-        <halign>center</halign>
-    </text>
-	
-	<group>
-		<layout>hbox</layout>
-		<default-padding>5</default-padding>
-		<empty><stretch>1</stretch></empty>
-		<halign>left</halign>
-		<checkbox>
-			<label> Human models</label>
-			<property>/sim/model/occupants</property>
-			<live>true</live>
-			<binding>
-				<command>dialog-apply</command>
-			</binding>
-		</checkbox>
-	</group>
-	
-	<text>  
-        <label>--------------------------</label>
-        <halign>center</halign>
-    </text>
-	
-	<group>
-		<layout>hbox</layout>
-		<text>
-			<label>Bush Kit Options</label>
-			<halign>center</halign>
-		</text>
-	</group>
+    <nasal>
+        <open>
+            var init = func {
+                # Bush kit
+                var p = getprop("fdm/jsbsim/bushkit");
+                setprop("/sim/model/c172p/bushkit_flag_0",0);
+                setprop("/sim/model/ec130/bushkit_flag_1",0);
+                setprop("/sim/model/ec130/bushkit_flag_2",0);
+                if (p == 0) { setprop("/sim/model/c172p/bushkit_flag_0",1); }
+                if (p == 1) { setprop("/sim/model/c172p/bushkit_flag_1",1); }
+                if (p == 2) { setprop("/sim/model/c172p/bushkit_flag_2",1); }
 
-	<group>
-		<layout>table</layout>
-		<default-padding>5</default-padding>
-		<halign>left</halign>
+                # Shadow volume
+                var p = getprop("/sim/rendering/shadow-volume");
+                if (p and !c172p.check_eligibility()) {
+                    setprop("/sim/rendering/shadow-volume", 0);
+                }
+            }
 
-		<text>
-           <row>0</row>
-           <col>0</col>
-           <label> </label>
-           <halign>left</halign>
-         </text>
-		 
-		<radio>
-			<row>0</row>
-			<col>1</col>
-			<halign>left</halign>
-			<label>Default Tire</label>
-			<property>sim/model/c172p/bushkit_flag_0</property>
-			<live>true</live>
-			<binding>
-				<command>dialog-apply</command>
-			</binding>
-			<binding>
-				<command>nasal</command>
-				<script>
-					setprop("fdm/jsbsim/bushkit", 0);
-					setprop("sim/model/c172p/bushkit_flag_0",1);
-					setprop("sim/model/c172p/bushkit_flag_1",0);
-					setprop("sim/model/c172p/bushkit_flag_2",0);
-				</script>
-			</binding>
-		</radio>
+            init();
+        </open>
+    </nasal>
 
-		<radio>
-			<row>0</row>
-			<col>2</col>
-			<halign>left</halign>
-			<label>26"</label>
-			<property>sim/model/c172p/bushkit_flag_1</property>
-			<live>true</live>
-			<binding>
-				<command>dialog-apply</command>
-			</binding>
-			<binding>
-				<command>nasal</command>
-				<script>
-					setprop("fdm/jsbsim/bushkit", 1);
-					setprop("sim/model/c172p/bushkit_flag_0",0);
-					setprop("sim/model/c172p/bushkit_flag_1",1);
-					setprop("sim/model/c172p/bushkit_flag_2",0);
-				</script>
-			</binding>
-		</radio>
+    <group>
+        <layout>hbox</layout>
 
-		 <radio>
-			<row>0</row>
-			<col>3</col>
-			<halign>left</halign>
-			<label> 36"</label>
-			<property>sim/model/c172p/bushkit_flag_2</property>
-			<live>true</live>
-			<binding>
-				<command>dialog-apply</command>
-			</binding>
-			<binding>
-				<command>nasal</command>
-				<script>
-					setprop("fdm/jsbsim/bushkit", 2);
-					setprop("sim/model/c172p/bushkit_flag_0",0);
-					setprop("sim/model/c172p/bushkit_flag_1",0);
-					setprop("sim/model/c172p/bushkit_flag_2",1);
-				</script>
-			</binding>
-		</radio>
-		 
-	</group>
-	
-	<group>
-		<layout>hbox</layout>
-		<default-padding>5</default-padding>
-	</group>
-	
-	<hrule/>
-	
-	<group>
-		<layout>hbox</layout>
-		<default-padding>5</default-padding>
+        <empty><stretch>true</stretch></empty>
+        <text>
+            <label>Aircraft Options</label>
+        </text>
+        <empty><stretch>true</stretch></empty>
 
-		<button>
-			<legend>Close</legend>
-			<equal>true</equal>
-			<key>Esc</key>
-			<default>true</default>
-			<binding>
-				<command>dialog-close</command>
-			</binding>
-		</button>
-	</group>
+        <button>
+            <legend/>
+            <key>Esc</key>
+            <pref-width>16</pref-width>
+            <pref-height>16</pref-height>
+            <binding>
+                <command>dialog-close</command>
+            </binding>
+        </button>
+    </group>
+
+    <hrule/>
+
+    <group>
+        <layout>vbox</layout>
+        <padding>6</padding>
+
+        <group>
+            <layout>vbox</layout>
+
+            <checkbox>
+                <halign>left</halign>
+                <label>Start with engine running</label>
+                <property>/fdm/jsbsim/running</property>
+                <live>true</live>
+                <binding>
+                    <command>dialog-apply</command>
+                </binding>
+            </checkbox>
+
+            <checkbox>
+                <halign>left</halign>
+                <label>Complex start up procedures</label>
+                <property>/fdm/jsbsim/complex</property>
+                <live>true</live>
+                <binding>
+                    <command>dialog-apply</command>
+                </binding>
+            </checkbox>
+        </group>
+
+        <hrule/>
+
+        <group>
+            <layout>hbox</layout>
+
+            <checkbox>
+                <halign>left</halign>
+                <label>Damage</label>
+                <property>/fdm/jsbsim/damage</property>
+                <live>true</live>
+                <binding>
+                    <command>dialog-apply</command>
+                </binding>
+            </checkbox>
+
+            <button>
+                <halign>right</halign>
+                <legend>Repair</legend>
+                <pref-width>60</pref-width>
+                <pref-height>28</pref-height>
+                <binding>
+                    <command>nasal</command>
+                    <script>c172p.resetalldamage()</script>
+                </binding>
+            </button>
+        </group>
+
+        <hrule/>
+
+        <group>
+            <layout>vbox</layout>
+
+            <checkbox>
+            <halign>left</halign>
+                <label>Shadow volume</label>
+                <property>/sim/rendering/shadow-volume</property>
+                <live>true</live>
+                <binding>
+                    <command>nasal</command>
+                    <script>c172p.toggle_shadow_volume()</script>
+                </binding>
+            </checkbox>
+
+            <checkbox>
+            <halign>left</halign>
+                <label>Human models</label>
+                <property>/sim/model/occupants</property>
+                <live>true</live>
+                <binding>
+                    <command>dialog-apply</command>
+                </binding>
+            </checkbox>
+        </group>
+
+        <hrule/>
+
+        <group>
+            <layout>vbox</layout>
+
+            <text>
+                <label>Bush Kit Options</label>
+                <halign>center</halign>
+            </text>
+
+            <group>
+                <layout>hbox</layout>
+
+                <radio>
+                    <halign>left</halign>
+                    <label>Default tire</label>
+                    <property>sim/model/c172p/bushkit_flag_0</property>
+                    <live>true</live>
+                    <binding>
+                        <command>dialog-apply</command>
+                    </binding>
+                    <binding>
+                        <command>nasal</command>
+                        <script>
+                            setprop("fdm/jsbsim/bushkit", 0);
+                            setprop("sim/model/c172p/bushkit_flag_0",1);
+                            setprop("sim/model/c172p/bushkit_flag_1",0);
+                            setprop("sim/model/c172p/bushkit_flag_2",0);
+                        </script>
+                    </binding>
+                </radio>
+
+                <radio>
+                    <halign>left</halign>
+                    <label>26"</label>
+                    <property>sim/model/c172p/bushkit_flag_1</property>
+                    <live>true</live>
+                    <binding>
+                        <command>dialog-apply</command>
+                    </binding>
+                    <binding>
+                        <command>nasal</command>
+                        <script>
+                            setprop("fdm/jsbsim/bushkit", 1);
+                            setprop("sim/model/c172p/bushkit_flag_0",0);
+                            setprop("sim/model/c172p/bushkit_flag_1",1);
+                            setprop("sim/model/c172p/bushkit_flag_2",0);
+                        </script>
+                    </binding>
+                </radio>
+
+                <radio>
+                    <halign>left</halign>
+                    <label> 36"</label>
+                    <property>sim/model/c172p/bushkit_flag_2</property>
+                    <live>true</live>
+                    <binding>
+                        <command>dialog-apply</command>
+                    </binding>
+                    <binding>
+                        <command>nasal</command>
+                        <script>
+                            setprop("fdm/jsbsim/bushkit", 2);
+                            setprop("sim/model/c172p/bushkit_flag_0",0);
+                            setprop("sim/model/c172p/bushkit_flag_1",0);
+                            setprop("sim/model/c172p/bushkit_flag_2",1);
+                        </script>
+                    </binding>
+                </radio>
+            </group>
+        </group>
+    </group>
+
+    <hrule/>
+
+    <group>
+        <layout>hbox</layout>
+        <default-padding>6</default-padding>
+
+        <empty><stretch>true</stretch></empty>
+
+        <button>
+            <legend>Close</legend>
+            <equal>true</equal>
+            <key>Esc</key>
+            <default>true</default>
+            <binding>
+                <command>dialog-close</command>
+            </binding>
+        </button>
+    </group>
+
 </PropertyList>
-

--- a/gui/dialogs/c172p-menu.xml
+++ b/gui/dialogs/c172p-menu.xml
@@ -2,40 +2,43 @@
 
 <PropertyList>
 
-  <default>
-    <menu n="10">
-      <label>Cessna C172P</label>
-      <enabled type="bool">true</enabled>
-	  
-	  <item>
-        <label>Aircraft options</label>
-        <binding>
-			<command>dialog-show</command>
-			<dialog-name>aircraft-dialog</dialog-name>
-        </binding>
-      </item>
-	  <item>
-        <label>Select livery</label>
-        <binding>
-          <command>nasal</command>
-          <script>aircraft.livery.dialog.toggle()</script>
-        </binding>
-      </item>
-      <item>
-        <label>Immatriculation</label>
-        <binding>
-		  <command>dialog-show</command>
-		  <dialog-name>immat-dialog</dialog-name>
-        </binding>
-      </item>
-      <item>
-        <name>Autostart</name>
-        <binding>
-          <command>nasal</command>
-          <script>c172p.autostart()</script>
-        </binding>
-      </item>
-    </menu>
-  </default>
+    <default>
+        <menu n="10">
+            <label>Cessna C172P</label>
+            <enabled type="bool">true</enabled>
+
+            <item>
+                <label>Aircraft options</label>
+                <binding>
+                    <command>dialog-show</command>
+                    <dialog-name>aircraft-dialog</dialog-name>
+                </binding>
+            </item>
+
+            <item>
+                <label>Select livery</label>
+                <binding>
+                    <command>nasal</command>
+                    <script>aircraft.livery.dialog.toggle()</script>
+                </binding>
+            </item>
+
+            <item>
+                <label>Registration</label>
+                <binding>
+                    <command>dialog-show</command>
+                    <dialog-name>registration-dialog</dialog-name>
+                </binding>
+            </item>
+
+            <item>
+                <name>Autostart</name>
+                <binding>
+                    <command>nasal</command>
+                    <script>c172p.autostart()</script>
+                </binding>
+            </item>
+        </menu>
+    </default>
 
 </PropertyList>

--- a/gui/dialogs/immat.xml
+++ b/gui/dialogs/immat.xml
@@ -2,61 +2,84 @@
 
 <PropertyList>
 
-  <name>immat-dialog</name>
-  <layout>vbox</layout>
-  <modal>false</modal>
-  <draggable>true</draggable>
-  <default-padding>3</default-padding>
+    <name>registration-dialog</name>
+    <layout>vbox</layout>
+    <resizable>false</resizable>
+    <modal>false</modal>
+    <draggable>true</draggable>
 
-  
-  <group>	
-		<layout>hbox</layout>
-		<default-padding>5</default-padding>
-		<empty><stretch>1</stretch></empty>
-		<text>
-			<label>Immatriculation</label>
-		</text>
-		<empty><stretch>true</stretch></empty>
-		<button>
-			<legend></legend>
-			<key>Esc</key>
-			<pref-width>16</pref-width>
-			<pref-height>16</pref-height>
-			<binding>
-				<command>dialog-close</command>
-			</binding>
-		</button>
-	</group>
+    <group>
+        <layout>hbox</layout>
 
-  <hrule/>
-	
-  <group>
-    <layout>hbox</layout>
-	<default-padding>5</default-padding>
-	<empty><stretch>1</stretch></empty>
-	<halign>center</halign>
-    <input>
-      <property>/sim/model/immat</property>
-      <type>STRING</type>
-      <width>100</width>
-    </input>
-  </group>
+        <empty><stretch>true</stretch></empty>
+        <text>
+            <label>Registration</label>
+        </text>
+        <empty><stretch>true</stretch></empty>
 
-  <hrule/>
-	 
-  <group>
-    <layout>hbox</layout>
-    <default-padding>5</default-padding>
-	<empty><stretch>1</stretch></empty>
-    <button>
-      <legend>OK</legend>
-      <equal>true</equal>
-      <default>true</default>
-      <key>Esc</key>
-      <binding><command>dialog-apply</command></binding>
-      <binding><command>dialog-close</command></binding>
-    </button>
-    <empty><stretch>true</stretch></empty>
-  </group>
+        <button>
+            <legend/>
+            <key>Esc</key>
+            <pref-width>16</pref-width>
+            <pref-height>16</pref-height>
+            <binding>
+                <command>dialog-close</command>
+            </binding>
+        </button>
+    </group>
+
+    <hrule/>
+
+    <group>
+        <layout>vbox</layout>
+        <padding>6</padding>
+
+        <group>
+            <layout>hbox</layout>
+
+            <text>
+                <label>Registration number:</label>
+                <halign>left</halign>
+            </text>
+
+            <input>
+                <halign>left</halign>
+                <property>/sim/model/immat</property>
+                <type>STRING</type>
+                <width>100</width>
+            </input>
+        </group>
+    </group>
+
+    <hrule/>
+
+    <group>
+        <layout>hbox</layout>
+        <default-padding>6</default-padding>
+
+        <empty><stretch>true</stretch></empty>
+
+        <button>
+            <legend>Apply</legend>
+            <equal>true</equal>
+            <default>false</default>
+            <binding>
+                <command>dialog-apply</command>
+            </binding>
+            <binding>
+                <command>dialog-close</command>
+            </binding>
+        </button>
+
+        <button>
+            <legend>Cancel</legend>
+            <equal>true</equal>
+            <key>Esc</key>
+            <default>true</default>
+            <binding>
+                <command>dialog-close</command>
+            </binding>
+        </button>
+    </group>
 
 </PropertyList>


### PR DESCRIPTION
Cleaned up the two XML files, formatting, and tabs+spaces mixture mess.

Aircraft Options:
* Reduced padding and code size
* Replaced the "----" lines with orange horizontal lines

Immatriculation / Registration:
* Renamed "Immatriculation" (is this French?) to "Registration"
* Replaced "OK" button with "Apply" and "Cancel" buttons