### PR TITLE
Mixture and Throttle levers control by scroll wheel, inversion

### DIFF
--- a/Models/c172p-detailed.xml
+++ b/Models/c172p-detailed.xml
@@ -2355,7 +2355,7 @@
      <binding>
        <command>property-adjust</command>
        <property>controls/engines/engine[0]/throttle</property>
-       <factor>0.05</factor>
+       <factor>-0.05</factor>
        <min>0</min>
        <max>1</max>
        <wrap>0</wrap>
@@ -2400,7 +2400,7 @@
      <binding>
        <command>property-adjust</command>
        <property>controls/engines/engine[0]/mixture-lever</property>
-       <factor>0.05</factor>
+       <factor>-0.05</factor>
        <min>0</min>
        <max>1</max>
        <wrap>0</wrap>


### PR DESCRIPTION
Were counter-intuitive.
issue https://github.com/Juanvvc/c172p-detailed/issues/156#event-300990125