### PR TITLE
Fuel management: Float chamber

### DIFF
--- a/Systems/fuel.xml
+++ b/Systems/fuel.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0"?>
+ 
+<!--
+***********************************************************************************
+c172p-detailed, May 2015 
+Fuel system for JSBSim FDM
+***********************************************************************************
+ -->
+
+<system name="fuel">
+
+<!-- *********************************************************************************** -->
+<!-- ****** Collector Tank 2 works like a constant-level carburetor float chamber ****** -->
+<!-- ************ From Tank 0 and / or Tank 1 (for Tank 2 level maintenance)  ********** -->
+<!-- *********************************************************************************** -->
+
+    <channel name="Constant level carburetor">
+        <!-- from Tank0 (to Collector Tank 2) Fuel Flow Rate in pps -->
+        <switch name="from tank0">
+            <default value="0"/>
+            <test logic="AND" value="-0.1">
+                propulsion/tank[0]/priority EQ 1 
+                propulsion/tank[0]/contents-lbs GT 0
+                /consumables/fuel/tank[2]/level-lbs LT 0.05
+                propulsion/tank[2]/priority EQ 1
+                accelerations/Nz GE 0
+            </test>            
+            <output>propulsion/tank[0]/external-flow-rate-pps</output>
+        </switch>
+
+        <!-- from Tank 1 (to Collector Tank 2) Fuel Flow Rate in pps -->
+        <switch name="from tank1">
+            <default value="0"/>
+            <test logic="AND" value="-0.1">
+                propulsion/tank[1]/priority EQ 1 
+                propulsion/tank[1]/contents-lbs GT 0
+                /consumables/fuel/tank[2]/level-lbs LT 0.05
+                propulsion/tank[2]/priority EQ 1
+                accelerations/Nz GE 0
+            </test>            
+            <output>propulsion/tank[1]/external-flow-rate-pps</output>
+        </switch>
+    </channel>
+
+<!-- *********************************************************************************** -->
+<!-- ************ Totalfrom Tank 0 and Tank 1 to Collector Tank 2  ********************* -->
+<!-- *********************************************************************************** -->
+
+    <channel name="Total flow rate into tank 2">
+        <summer name="to tank2">
+            <input>-propulsion/tank[0]/external-flow-rate-pps</input>
+            <input>-propulsion/tank[1]/external-flow-rate-pps</input>
+            <output>propulsion/tank[2]/external-flow-rate-pps</output>
+        </summer>
+    </channel>
+ 
+</system>

--- a/c172p-detailed-set.xml
+++ b/c172p-detailed-set.xml
@@ -269,6 +269,11 @@ Many files from the original c172p directory are included in this file.
     <level-gal_us type="double">20</level-gal_us>
     <selected type="bool">true</selected>
    </tank>
+   <tank n="2">
+    <name>Float chamber</name>
+    <capacity unit="LBS"> 0.1 </capacity>
+    <selected type="bool">true</selected>
+   </tank>
   </fuel>
  </consumables>
 

--- a/c172p-fdm-dany93.xml
+++ b/c172p-fdm-dany93.xml
@@ -271,8 +271,7 @@
                 <pitch> 0 </pitch>
                 <yaw> 0 </yaw>
             </orient>
-            <feed>0</feed>
-            <feed>1</feed>
+            <feed>2</feed> <!-- from intermediate tank (float chamber) -->
             <thruster file="prop_75in2f">
                 <location unit="IN">
                     <x> -37.7 </x>
@@ -306,8 +305,20 @@
             <capacity unit="LBS"> 185 </capacity>
             <contents unit="LBS"> 100 </contents>
         </tank>
+        <tank type="FUEL">    <!-- Tank number 2, Float chamber  -->
+            <location unit="IN">
+                <x> 56 </x>
+                <y> 0 </y>
+                <z> 59.4 </z>
+            </location>
+            <capacity unit="LBS"> 0.1 </capacity>
+            <contents unit="LBS"> 0 </contents>
+            <priority>1</priority>
+        </tank>
     </propulsion>
-
+    
+ <system file="fuel"/>
+	
     <flight_control name="FCS: c172">
         <channel name="Pitch">
             <summer name="Pitch Trim Sum">

--- a/c172p.xml
+++ b/c172p.xml
@@ -265,8 +265,7 @@
                 <pitch> 0 </pitch>
                 <yaw> 0 </yaw>
             </orient>
-            <feed>0</feed>
-            <feed>1</feed>
+            <feed>2</feed> <!-- from intermediate tank (float chamber) -->
             <thruster file="prop_75in2f">
                 <location unit="IN">
                     <x> -37.7 </x>
@@ -300,7 +299,19 @@
             <capacity unit="LBS"> 185 </capacity>
             <contents unit="LBS"> 100 </contents>
         </tank>
+        <tank type="FUEL">    <!-- Tank number 2, Float chamber  -->
+            <location unit="IN">
+                <x> 56 </x>
+                <y> 0 </y>
+                <z> 59.4 </z>
+            </location>
+            <capacity unit="LBS"> 0.1 </capacity>
+            <contents unit="LBS"> 0 </contents>
+            <priority>1</priority>
+        </tank>
     </propulsion>
+    
+ <system file="fuel"/>
 	
     <flight_control name="FCS: c172">
         <channel name="Pitch">


### PR DESCRIPTION
Float chamber added.
In a first time, on the original FDM only (c172p.xml) for testing.

I've given some explanations in this post
http://forum.flightgear.org/viewtopic.php?f=4&t=25157&start=1395#p242612

To quickly see and understand the effects:
Full throttle with parking brake.
See "Fuel and payload", and fiddle with the main tanks [0] and [1] levels, or close them one by one. Observe the Float chamber [2] level.

A g < 0 feature is implemented, which stops the engine in some seconds. Fly with some negative g's (pushing the yoke in a climb is enough) and look at the floating chamber level.

Any(?) Other properties can be inserted in fuel.xml (switch tests). Setting these properties by any other way can starve or quickly stop the engine, or prevent it from starting ("primer 3 times" linked property?).