### PR TITLE
Battery master needs to be on to check fuel gauges

### DIFF
--- a/c172-checklists.xml
+++ b/c172-checklists.xml
@@ -80,6 +80,24 @@
       </marker>
     </item>
     <item>
+      <name>Battery Master Switch</name>
+      <value>ON</value>
+      <marker>
+        <x-m>-0.3500</x-m>
+        <y-m>-0.4000</y-m>
+        <z-m>-0.2300</z-m>
+        <scale>1.0000</scale>
+      </marker>
+      <condition>
+        <property>/controls/engines/engine[0]/master-bat</property>
+      </condition>
+      <binding>
+        <command>property-assign</command>
+        <property>/controls/engines/engine[0]/master-bat</property>
+        <value type="bool">true</value>
+      </binding>
+    </item>
+    <item>
       <name>Fuel Quantity</name>
       <value>CHECK</value>
       <marker>
@@ -239,24 +257,6 @@
     <item>
       <name>Propellor Area</name>
       <value>CLEAR</value>
-    </item>
-    <item>
-      <name>Battery Master Switch</name>
-      <value>ON</value>
-      <marker>
-        <x-m>-0.3500</x-m>
-        <y-m>-0.4000</y-m>
-        <z-m>-0.2300</z-m>
-        <scale>1.0000</scale>
-      </marker>
-      <condition>
-        <property>/controls/engines/engine[0]/master-bat</property>
-      </condition>
-      <binding>
-        <command>property-assign</command>
-        <property>/controls/engines/engine[0]/master-bat</property>
-        <value type="bool">true</value>
-      </binding>
     </item>
     <item>
       <name>Magnetos</name>


### PR DESCRIPTION
This is not 100% accurate, as per the C172 operating handbook the fuel gauges are checked during the preflight check. However the complete preflight check is not included in the checklists, and the fuel gauge check is instead part of the "before starting engine" checklist, which makes sense in practice. So we need to move the battery master item a few lines higher to be able to see the fuel gauge values. 

In the handbook the battery is turned off afterwards to save the battery since the preflight takes a while, but turning it off here does not make sense, as you'll be starting the engine in a few moments anyway in the sim when you follow the list.