### PR TITLE
Point to correct gauge

### DIFF
--- a/c172-checklists.xml
+++ b/c172-checklists.xml
@@ -80,24 +80,6 @@
       </marker>
     </item>
     <item>
-      <name>Battery Master Switch</name>
-      <value>ON</value>
-      <marker>
-        <x-m>-0.3500</x-m>
-        <y-m>-0.4000</y-m>
-        <z-m>-0.2300</z-m>
-        <scale>1.0000</scale>
-      </marker>
-      <condition>
-        <property>/controls/engines/engine[0]/master-bat</property>
-      </condition>
-      <binding>
-        <command>property-assign</command>
-        <property>/controls/engines/engine[0]/master-bat</property>
-        <value type="bool">true</value>
-      </binding>
-    </item>
-    <item>
       <name>Fuel Quantity</name>
       <value>CHECK</value>
       <marker>
@@ -259,6 +241,24 @@
       <value>CLEAR</value>
     </item>
     <item>
+      <name>Battery Master Switch</name>
+      <value>ON</value>
+      <marker>
+        <x-m>-0.3500</x-m>
+        <y-m>-0.4000</y-m>
+        <z-m>-0.2300</z-m>
+        <scale>1.0000</scale>
+      </marker>
+      <condition>
+        <property>/controls/engines/engine[0]/master-bat</property>
+      </condition>
+      <binding>
+        <command>property-assign</command>
+        <property>/controls/engines/engine[0]/master-bat</property>
+        <value type="bool">true</value>
+      </binding>
+    </item>
+    <item>
       <name>Magnetos</name>
       <value>BOTH</value>
       <value>(press } three times)</value>
@@ -296,10 +296,10 @@
       <value>CHECK</value>
       <value>(if not GREEN before 30s, secure airplane)</value>
       <marker>
-        <x-m>-0.3600</x-m>
-        <y-m>-0.4200</y-m>
+        <x-m>-0.3700</x-m>
+        <y-m>-0.3850</y-m>
         <z-m>-0.0600</z-m>
-        <scale>1.0000</scale>
+        <scale>1.4000</scale>
       </marker>
     </item>
     <item>


### PR DESCRIPTION
This was pointing at the oil temperature gauge, which is not what you need to look at after the engine starts, it takes longer to move towards green. Fixing to point the marker at oil pressure gauge and scaled it a bit larger as well so you can see the value without the marker blocking it.