### PR TITLE
Do not apply brake if corresponding gear is damaged

### DIFF
--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -1,4 +1,35 @@
 ##########################################
+# Brakes
+##########################################
+
+controls.applyBrakes = func (v, which = 0) {
+    if (which <= 0 and !getprop("/fdm/jsbsim/gear/unit[1]/broken")) {
+        interpolate("/controls/gear/brake-left", v, controls.fullBrakeTime);
+    }
+    if (which >= 0 and !getprop("/fdm/jsbsim/gear/unit[2]/broken")) {
+        interpolate("/controls/gear/brake-right", v, controls.fullBrakeTime);
+    }
+};
+
+controls.applyParkingBrake = func (v) {
+    if (!v) {
+        return;
+    }
+
+    var left_broken = getprop("/fdm/jsbsim/gear/unit[1]/broken");
+    var right_broken =getprop("/fdm/jsbsim/gear/unit[2]/broken");
+    var p = "/controls/gear/brake-parking";
+    var orig_p = getprop(p);
+
+    # We assume one non-broken gear is enough to apply the parking brake
+    if (orig_p or !left_broken or !right_broken) {
+        setprop(p, var i = !orig_p);
+        return i;
+    }
+    return orig_p;
+};
+
+##########################################
 # Ground Detection
 ##########################################
 


### PR DESCRIPTION
Fixes #149

I think the proper fix though is to make sure JSBSim doesn't listen to the `/controls/gear` properties instead of (not) manipulating them.

For example, if you apply parking brake and then break all your gear by crashing, then currently JSBSim will apply the parking brake because the `/controls/gear/brake-parking` was already true before the gears got broken. But this issue only happens with the parking brake, not the normal brakes, because those return to 0 eventually.