### PR TITLE
Added missing var-keywords in the Nasal files.

### DIFF
--- a/Nasal/avionics.nas
+++ b/Nasal/avionics.nas
@@ -16,9 +16,9 @@
 ki266.new(0);
 aircraft.data.add("engines/engine[0]/egt-bug-norm");
 
-headingNeedleDeflection = "/instrumentation/nav/heading-needle-deflection";
-gsNeedleDeflection = "/instrumentation/nav/gs-needle-deflection-norm";
-staticPressure = "systems/static/pressure-inhg";
+var headingNeedleDeflection = "/instrumentation/nav/heading-needle-deflection";
+var gsNeedleDeflection = "/instrumentation/nav/gs-needle-deflection-norm";
+var staticPressure = "systems/static/pressure-inhg";
 
 # Save the state of the avionics Radio control panel (according to its
 # documentation)

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -159,7 +159,7 @@ var reset_system = func {
 # Global loop function
 # If you need to run nasal as loop, add it in this function
 ############################################
-global_system_loop = func{
+var global_system_loop = func{
 
   # terrain_survol_loop was incorporated during damage system creation. 
   # "Unimplemented" crash detection system requires this self terrain modelling (I think)

--- a/Nasal/doors.nas
+++ b/Nasal/doors.nas
@@ -1,4 +1,4 @@
 # doors ============================================================
-leftDoor = aircraft.door.new( "/sim/model/door-positions/leftDoor", 2, 0 );
-rightDoor = aircraft.door.new( "/sim/model/door-positions/rightDoor", 2, 0 );
-baggageDoor = aircraft.door.new( "/sim/model/door-positions/baggageDoor", 2, 0 );
+var leftDoor = aircraft.door.new( "/sim/model/door-positions/leftDoor", 2, 0 );
+var rightDoor = aircraft.door.new( "/sim/model/door-positions/rightDoor", 2, 0 );
+var baggageDoor = aircraft.door.new( "/sim/model/door-positions/baggageDoor", 2, 0 );

--- a/Nasal/electrical.nas
+++ b/Nasal/electrical.nas
@@ -27,7 +27,7 @@ var DELAY_SECS = 3;
 # Initialize the electrical system
 #
 
-init_electrical = func {
+var init_electrical = func {
     battery = BatteryClass.new();
     alternator = AlternatorClass.new();
     
@@ -66,7 +66,7 @@ init_electrical = func {
 # Battery model class.
 #
 
-BatteryClass = {};
+var BatteryClass = {};
 
 BatteryClass.new = func {
     var obj = { parents : [BatteryClass],
@@ -135,7 +135,7 @@ BatteryClass.get_output_amps = func {
 # Alternator model class.
 #
 
-AlternatorClass = {};
+var AlternatorClass = {};
 
 AlternatorClass.new = func {
     var obj = { parents : [AlternatorClass],
@@ -205,7 +205,7 @@ AlternatorClass.get_output_amps = func {
 # This is the main electrical system update function.
 #
 
-update_electrical = func {
+var update_electrical = func {
     var time = getprop("/sim/time/elapsed-sec");
     var dt = time - last_time;
     last_time = time;
@@ -222,7 +222,7 @@ update_electrical = func {
 # alternator, starter, master/alt switches, external power supply.
 #
 
-update_virtual_bus = func( dt ) {
+var update_virtual_bus = func( dt ) {
     var serviceable = getprop("/systems/electrical/serviceable");
     var external_volts = 0.0;
     var load = 0.0;
@@ -302,7 +302,7 @@ update_virtual_bus = func( dt ) {
 }
 
 
-electrical_bus_1 = func() {
+var electrical_bus_1 = func() {
     var bus_volts = 0.0;
     var load = 0.0;
     
@@ -449,7 +449,7 @@ electrical_bus_1 = func() {
     return load;
 }
 
-avionics_bus_1 = func() {
+var avionics_bus_1 = func() {
     var bus_volts = 0.0;
     var load = 0.0;
 

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -9,7 +9,7 @@
 
 # set the update period
 
-UPDATE_PERIOD = 0.3;
+var UPDATE_PERIOD = 0.3;
 
 # =============================== Hobbs meter =======================================
 
@@ -28,7 +28,7 @@ setlistener("/engines/engine[0]/running", func {
 
 setlistener("/sim/time/hobbs/engine[0]", func {
     # in seconds
-    hobbs = getprop("/sim/time/hobbs/engine[0]") or 0.0;
+    var hobbs = getprop("/sim/time/hobbs/engine[0]") or 0.0;
     # This uses minutes, for testing
     #hobbs = hobbs / 60.0;
     # in hours
@@ -117,7 +117,7 @@ var update = func {
 
 # controls.startEngine = func(v = 1) {
 setlistener("/controls/switches/starter", func {
-    v = getprop("/controls/switches/starter") or 0;
+    var v = getprop("/controls/switches/starter") or 0;
     if (v == 0) {
         print("Starter off");
         # notice the starter will be reset after 5 seconds

--- a/Nasal/immat.nas
+++ b/Nasal/immat.nas
@@ -3,6 +3,7 @@
 # ===========================
 
 var refresh_immat = func {
+    var glyph = nil;
     var immat = props.globals.getNode("/sim/model/immat",1).getValue();
     var immat_size = size(immat);
     if (immat_size != 0) immat = string.uc(immat);


### PR DESCRIPTION
While leaving out the var keyword when introducing new identifiers is not an error it is not a good practice since the behaviour can change from creating a new local variable to overwriting visible one without any notice (e.g. if a later added global module happens to have the same name as the new variable). Using var always creates a new local (= present module or function) variable and will never overwrite a larger scoped visible one, should one exist.