### PR TITLE
Hid FDM internal weights from the fuel and payload dialog.

### DIFF
--- a/Systems/bushkit.xml
+++ b/Systems/bushkit.xml
@@ -16,7 +16,7 @@ Extra weight and drag due to bush wheels or floats
             <test logic="AND" value="20">
                 bushkit EQ 1
             </test>            
-            <output>/payload/weight[5]/weight-lb</output>
+            <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[5]</output>
         </switch>
 
         <switch name="extra-weight-36-in">
@@ -24,7 +24,7 @@ Extra weight and drag due to bush wheels or floats
             <test logic="AND" value="30">
                 bushkit EQ 2
             </test>            
-            <output>/payload/weight[6]/weight-lb</output>
+            <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[6]</output>
         </switch>
 
         <switch name="extra-weight-Floats">
@@ -32,7 +32,7 @@ Extra weight and drag due to bush wheels or floats
             <test logic="AND" value="132">
                 bushkit EQ 3
             </test>            
-            <output>/payload/weight[7]/weight-lb</output>
+            <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[7]</output>
         </switch>
 
         <switch name="extra-weight-Amphibious">
@@ -40,7 +40,7 @@ Extra weight and drag due to bush wheels or floats
             <test logic="AND" value="276">
                 bushkit EQ 4
             </test>            
-            <output>/payload/weight[8]/weight-lb</output>
+            <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[8]</output>
         </switch>
 
     </channel>

--- a/c172p-detailed-set.xml
+++ b/c172p-detailed-set.xml
@@ -406,30 +406,6 @@ Many files from the original c172p directory are included in this file.
    <min-lb type="double">0.0</min-lb>
    <max-lb type="double">150.0</max-lb> <!-- WARNING: Max baggage "by the book" is 120lbs or less! -->
   </weight>
-  <weight>
-   <name type="string">wheels 26"</name>
-   <weight-lb alias="/fdm/jsbsim/inertia/pointmass-weight-lbs[5]"/>
-   <min-lb type="double">0.0</min-lb>
-   <max-lb type="double">100</max-lb>
-  </weight>
-  <weight>
-   <name type="string">wheels 36"</name>
-   <weight-lb alias="/fdm/jsbsim/inertia/pointmass-weight-lbs[6]"/>
-   <min-lb type="double">0.0</min-lb>
-   <max-lb type="double">100</max-lb>
-  </weight>
-    <weight>
-   <name type="string">Floats</name>
-   <weight-lb alias="/fdm/jsbsim/inertia/pointmass-weight-lbs[7]"/>
-   <min-lb type="double">0.0</min-lb>
-   <max-lb type="double">400</max-lb>
-  </weight>
-  <weight>
-   <name type="string">Amphibious</name>
-   <weight-lb alias="/fdm/jsbsim/inertia/pointmass-weight-lbs[8]"/>
-   <min-lb type="double">0.0</min-lb>
-   <max-lb type="double">400</max-lb>
-  </weight>
  </payload>
 
  <limits>


### PR DESCRIPTION
Don't add /payload/weight entries for weights that the user should not see or touch in the fuel and payload dialog.

Signed-off-by: Anders Gidenstam <anders@gidenstam.org>