### PR TITLE
Subdivide left and right bushkits and floats weights

### DIFF
--- a/Systems/bushkit.xml
+++ b/Systems/bushkit.xml
@@ -11,36 +11,68 @@ Extra weight and drag due to bush wheels or floats
 
     <channel name="extra-weight">
        
-        <switch name="extra-weight-26-in">
+        <switch name="extra-weight-left-26-in">
             <default value="0"/>
-            <test logic="AND" value="20">
+            <test logic="AND" value="10">
                 bushkit EQ 1
             </test>            
             <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[5]</output>
         </switch>
-
-        <switch name="extra-weight-36-in">
+       
+        <switch name="extra-weight-right-26-in">
             <default value="0"/>
-            <test logic="AND" value="30">
-                bushkit EQ 2
+            <test logic="AND" value="10">
+                bushkit EQ 1
             </test>            
             <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[6]</output>
         </switch>
 
-        <switch name="extra-weight-Floats">
+        <switch name="extra-weight-left-36-in">
             <default value="0"/>
-            <test logic="AND" value="132">
-                bushkit EQ 3
+            <test logic="AND" value="15">
+                bushkit EQ 2
             </test>            
             <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[7]</output>
         </switch>
-
-        <switch name="extra-weight-Amphibious">
+        
+        <switch name="extra-weight-right-36-in">
             <default value="0"/>
-            <test logic="AND" value="276">
-                bushkit EQ 4
+            <test logic="AND" value="15">
+                bushkit EQ 2
             </test>            
             <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[8]</output>
+        </switch>
+
+        <switch name="extra-weight-left-float">
+            <default value="0"/>
+            <test logic="AND" value="66">
+                bushkit EQ 3
+            </test>            
+            <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[9]</output>
+        </switch>
+
+        <switch name="extra-weight-right-float">
+            <default value="0"/>
+            <test logic="AND" value="66">
+                bushkit EQ 3
+            </test>            
+            <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[10]</output>
+        </switch>
+
+        <switch name="extra-weight-left-amphibious">
+            <default value="0"/>
+            <test logic="AND" value="138">
+                bushkit EQ 4
+            </test>            
+            <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[11]</output>
+        </switch>
+
+        <switch name="extra-weight-right-amphibious">
+            <default value="0"/>
+            <test logic="AND" value="138">
+                bushkit EQ 4
+            </test>            
+            <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[12]</output>
         </switch>
 
     </channel>

--- a/c172p.xml
+++ b/c172p.xml
@@ -8,10 +8,11 @@
     <fileheader>
         <author> Unknown </author>
         <filecreationdate> 2002-01-01 </filecreationdate>
-        <version> $Id: c172p-fdm-dany93.xml,v 1.34 May 2015 $ </version>
+        <version> $Id: c172p.xml,v 1.40 June 2015 $ </version>
         <!-- experimental stall and spin, up to flat spin March 2014 -->
-        <!-- this file with comments to help -->
-		<!-- further modifications for c172p-detailed April - May 2015 -->
+        <!-- Source: http://forum.flightgear.org/viewtopic.php?f=25&t=21664&start=45 -->
+        <!-- this file with comments for stall and spin to help -->
+		<!-- further modifications for c172p-detailed 2015 -->
         <description> Cessna C-172 </description>
     </fileheader>
 
@@ -94,37 +95,69 @@
             </location>
         </pointmass>
         
-        <!-- Bushkits 1 to 4, pointmass [5] to [8] -->
+        <!-- Bushkits 1 to 4, pointmass [5] to [12] -->
         <!-- Weight and drag are managed by Systems/bushkit.xml -->
-        <pointmass name="Bush wheels 26 inches">
+        <pointmass name="Left bush wheel 26 inches">
             <weight unit="LBS"> 0 </weight>
             <location name="POINTMASS" unit="IN">
                 <x> 58.2 </x>
-                <y>  0 </y>
+                <y>  -43 </y>
                 <z> -15.5 </z>
             </location>
         </pointmass>
-        <pointmass name="Bush wheels 36 inches">
+        <pointmass name="Right bush wheel 26 inches">
             <weight unit="LBS"> 0 </weight>
             <location name="POINTMASS" unit="IN">
                 <x> 58.2 </x>
-                <y>  0 </y>
+                <y>  43 </y>
                 <z> -15.5 </z>
             </location>
         </pointmass>
-        <pointmass name="Floats">
+        <pointmass name="Left bush wheel 36 inches">
+            <weight unit="LBS"> 0 </weight>
+            <location name="POINTMASS" unit="IN">
+                <x> 58.2 </x>
+                <y>  -43 </y>
+                <z> -15.5 </z>
+            </location>
+        </pointmass>
+        <pointmass name="Right bush wheel 36 inches">
+            <weight unit="LBS"> 0 </weight>
+            <location name="POINTMASS" unit="IN">
+                <x> 58.2 </x>
+                <y>  43 </y>
+                <z> -15.5 </z>
+            </location>
+        </pointmass>
+        <pointmass name="Left float">
             <weight unit="LBS"> 0 </weight>
             <location name="POINTMASS" unit="IN">
                 <x> 41 </x>
-                <y>  0 </y>
+                <y>  -43 </y>
                 <z> -25 </z>
             </location>
         </pointmass>
-        <pointmass name="Amphibious">
+        <pointmass name="Right float">
             <weight unit="LBS"> 0 </weight>
             <location name="POINTMASS" unit="IN">
                 <x> 41 </x>
-                <y>  0 </y>
+                <y>  43 </y>
+                <z> -25 </z>
+            </location>
+        </pointmass>
+        <pointmass name="Left amphibious">
+            <weight unit="LBS"> 0 </weight>
+            <location name="POINTMASS" unit="IN">
+                <x> 41 </x>
+                <y>  -43 </y>
+                <z> -25 </z>
+            </location>
+        </pointmass>
+        <pointmass name="Right amphibious">
+            <weight unit="LBS"> 0 </weight>
+            <location name="POINTMASS" unit="IN">
+                <x> 41 </x>
+                <y>  43 </y>
                 <z> -25 </z>
             </location>
         </pointmass>


### PR DESCRIPTION
Previously, left and right were in a single load in the FDM, and every kit appeared in "Fuel and Payload" dialog with cursors.
After AndersG changes, https://github.com/Juanvvc/c172p-detailed/pull/232#issue-83163224, subdivision becomes possible with no useless lines in "fuel and payload". Clean.