### PR TITLE
Gear damage by the forces exerted on gears

### DIFF
--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -20,16 +20,18 @@ var aero_coeff = "fdm/jsbsim/aero/coefficient/";
 #Roll moment due to (diedra + roll rate + yaw rate + ailerons) ==> asymmetry to break one wing
 var roll_moment = getprop(aero_coeff~"Clb")+getprop(aero_coeff~"Clp")+getprop(aero_coeff~"Clr")+getprop(aero_coeff~"ClDa");
 
-# Force-on-gear = (compression-ft) x (spring_coeff) + (compression-velocity-fps) x (damping_coeff)
-var compr0 = getprop("/fdm/jsbsim/gear/unit[0]/compression-ft");
-var compr_vel0 = getprop("/fdm/jsbsim/gear/unit[0]/compression-velocity-fps");
-var force0 = 1800 * compr0 + 600 * compr_vel0; # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for NOSE
-var compr1 = getprop("/fdm/jsbsim/gear/unit[1]/compression-ft");
-var compr_vel1 = getprop("/fdm/jsbsim/gear/unit[1]/compression-velocity-fps");
-var force1 = 5400 * compr1 + 400 * compr_vel1; # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for LEFT gear
-var compr2 = getprop("/fdm/jsbsim/gear/unit[2]/compression-ft");
-var compr_vel2 = getprop("/fdm/jsbsim/gear/unit[2]/compression-velocity-fps");
-var force2 = 5400 * compr2 + 400 * compr_vel2; # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for RIGHT gear
+var get_gear_force = func (index, spring_coeff, damping_coeff) {
+    # Force-on-gear = (compression-ft) x (spring_coeff) + (compression-velocity-fps) x (damping_coeff)
+
+    var compr = getprop("/fdm/jsbsim/gear/unit", index, "compression-ft");
+    var compr_vel = getprop("/fdm/jsbsim/gear/unit", index, "compression-velocity-fps");
+    return spring_coeff * compr + damping_coeff * compr_vel;
+};
+
+var force0 = get_gear_force(0, 1800, 600); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for NOSE
+var force1 = get_gear_force(1, 5400, 400); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for LEFT gear
+var force2 = get_gear_force(2, 5400, 400); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for RIGHT gear
+
 var gear_side_force = getprop("/fdm/jsbsim/forces/fby-gear-lbs");
 
 var gears = "fdm/jsbsim/gear/";
@@ -279,23 +281,22 @@ var amphibious = func
 }
 
 var poll_damage = func
+{
 
 # GROUND DAMAGES
 
-{
+    get_gear_force = func (index, spring_coeff, damping_coeff) {
+        # Force-on-gear = (compression-ft) x (spring_coeff) + (compression-velocity-fps) x (damping_coeff)
+    
+        compr = getprop("/fdm/jsbsim/gear/unit", index, "compression-ft");
+        compr_vel = getprop("/fdm/jsbsim/gear/unit", index, "compression-velocity-fps");
+        return spring_coeff * compr + damping_coeff * compr_vel;
+    };
 
-    compr0 = getprop("/fdm/jsbsim/gear/unit[0]/compression-ft");
-    compr_vel0 = getprop("/fdm/jsbsim/gear/unit[0]/compression-velocity-fps");
-    force0 = 1800 * compr0 + 600 * compr_vel0; # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for NOSE
-     
-    compr1 = getprop("/fdm/jsbsim/gear/unit[1]/compression-ft");
-    compr_vel1 = getprop("/fdm/jsbsim/gear/unit[1]/compression-velocity-fps");
-    force1 = 5400 * compr1 + 400 * compr_vel1; # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for LEFT gear
-    
-    compr2 = getprop("/fdm/jsbsim/gear/unit[2]/compression-ft");
-    compr_vel2 = getprop("/fdm/jsbsim/gear/unit[2]/compression-velocity-fps");
-    force2 = 5400 * compr2 + 400 * compr_vel2; # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for RIGHT gear
-    
+    force0 = get_gear_force(0, 1800, 600); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for NOSE
+    force1 = get_gear_force(1, 5400, 400); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for LEFT gear
+    force2 = get_gear_force(2, 5400, 400); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for RIGHT gear
+
     gear_side_force = getprop("/fdm/jsbsim/forces/fby-gear-lbs");
     
 #    # For tests: forces (LBS) exerted on gears (along Z and Y)

--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -285,14 +285,6 @@ var poll_damage = func
 
 # GROUND DAMAGES
 
-    get_gear_force = func (index, spring_coeff, damping_coeff) {
-        # Force-on-gear = (compression-ft) x (spring_coeff) + (compression-velocity-fps) x (damping_coeff)
-    
-        compr = getprop("/fdm/jsbsim/gear/unit", index, "compression-ft");
-        compr_vel = getprop("/fdm/jsbsim/gear/unit", index, "compression-velocity-fps");
-        return spring_coeff * compr + damping_coeff * compr_vel;
-    };
-
     force0 = get_gear_force(0, 1800, 600); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for NOSE
     force1 = get_gear_force(1, 5400, 400); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for LEFT gear
     force2 = get_gear_force(2, 5400, 400); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for RIGHT gear

--- a/c172p.xml
+++ b/c172p.xml
@@ -189,7 +189,7 @@
             <dynamic_friction> 0.5 </dynamic_friction>
             <rolling_friction> 0.02 </rolling_friction>
             <spring_coeff unit="LBS/FT"> 5400 </spring_coeff>
-            <damping_coeff unit="LBS/FT/SEC"> 1600 </damping_coeff>
+            <damping_coeff unit="LBS/FT/SEC"> 400 </damping_coeff>
             <max_steer unit="DEG"> 0.0 </max_steer>
             <brake_group> LEFT </brake_group>
             <retractable>0</retractable>
@@ -204,7 +204,7 @@
             <dynamic_friction> 0.5 </dynamic_friction>
             <rolling_friction> 0.02 </rolling_friction>
             <spring_coeff unit="LBS/FT"> 5400 </spring_coeff>
-            <damping_coeff unit="LBS/FT/SEC"> 1600 </damping_coeff>
+            <damping_coeff unit="LBS/FT/SEC"> 400 </damping_coeff>
             <max_steer unit="DEG"> 0.0 </max_steer>
             <brake_group> RIGHT </brake_group>
             <retractable>0</retractable>


### PR DESCRIPTION
Connected to this issue https://github.com/Juanvvc/c172p-detailed/issues/134#issuecomment-107867029

Indeed, the nose gear is hard to break without breaking the others. 
For this nose gear, I had to set the breaking force at 1400 lbs because it reached 1392 lbs at the end of a strong braking with the 36" bushwheels (1350 lbs threshold is needed with the default wheels).

I have included the" tool" for printing the exerted forces because it can be useful elsewhere and by someone else (under comments, of course).

@tigert if you can see for the breaking threshold due to side force (15 kts crosswind landing, full load).
I have set it at 1500 lbs (Y-force).
500 lbs can be enough for a very good crosswind landing, but that's easy to reach 600 - 700 lbs only by rolling not very straight. 700 - 1000 lbs seems possible, but demanding.