### PR TITLE
Autostart: parking brake is OFF ==> deletion message 'release brakes'

### DIFF
--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -142,7 +142,7 @@ var autostart = func (msg=1) {
     #c172p.autoPrime();
     setprop("/controls/engines/engine/primer", 3);
 	if (msg)
-	    gui.popupTip("Hold down \"s\" to start the engine. After that, release brakes (press \"B\")", 5);
+	    gui.popupTip("Hold down \"s\" to start the engine", 5);
 };
 
 setlistener("/controls/switches/starter", func {


### PR DESCRIPTION
At "Autostart" the parking brake is OFF.
This popup message is useless and confusing.
 **Unless it is used elsewhere** (where?)