### PR TITLE
Make instrument lighting depend on master battery and circuit breaker

### DIFF
--- a/Models/Interior/Panel/Instruments/kap140/KAP140TwoAxisAlt.xml
+++ b/Models/Interior/Panel/Instruments/kap140/KAP140TwoAxisAlt.xml
@@ -83,7 +83,7 @@ properties' values.
       <red>0.75</red>
       <green>0.25</green>
       <blue>0.10</blue>
-      <factor-prop>/controls/lighting/panel-norm</factor-prop>
+      <factor-prop>/sim/model/material/instruments/factor</factor-prop>
     </emission>
   </animation>
 

--- a/Nasal/avionics.nas
+++ b/Nasal/avionics.nas
@@ -82,7 +82,6 @@ aircraft.data.add(
     "/controls/lighting/instruments-norm",
     "/controls/lighting/landing-lights",
     "/controls/lighting/nav-lights",
-    "/controls/lighting/panel-norm",
     "/controls/lighting/strobe",
     "/controls/lighting/taxi-light"
 );

--- a/Nasal/electrical.nas
+++ b/Nasal/electrical.nas
@@ -387,7 +387,7 @@ var electrical_bus_1 = func() {
         setprop("/systems/electrical/outputs/instrument-lights", bus_volts);
         load += bus_volts / 57;
     } else {
-        setprop("/systems/electrical/outputs/istrument-lights", 0.0);
+        setprop("/systems/electrical/outputs/instrument-lights", 0.0);
     }    
 
     # Landing Light Power

--- a/Nasal/light.nas
+++ b/Nasal/light.nas
@@ -2,27 +2,6 @@
 var strobe_switch = props.globals.getNode("/systems/electrical/outputs/strobe", 1);
 aircraft.light.new("sim/model/c172p/lighting/strobes", [0.015, 1.985], strobe_switch);
 
-
 # beacons ===========================================================
 var beacon_switch = props.globals.getNode("/systems/electrical/outputs/beacon", 1);
 aircraft.light.new("sim/model/c172p/lighting/beacon-top", [0.10, 0.90], beacon_switch);
-
-
-# Control both panel and instrument light intensity with one property
-var instrumentsNorm = props.globals.getNode("controls/lighting/instruments-norm", 1);
-var instrumentLightFactor = props.globals.getNode("sim/model/material/instruments/factor", 1);
-var panelLights = props.globals.getNode("controls/lighting/panel-norm", 1);
-
-var update_intensity = func {
-    instrumentLightFactor.setDoubleValue(instrumentsNorm.getValue());
-    panelLights.setDoubleValue(instrumentsNorm.getValue());
-
-    settimer(update_intensity, 0.1);
-}
-
-# Setup listener call to start update loop once the fdm is initialized,
-# but only start the update loop _once_.
-var fdm_init_listener = setlistener("sim/signals/fdm-initialized", func {
-    removelistener(fdm_init_listener);
-    update_intensity();
-});

--- a/Systems/als-lights.xml
+++ b/Systems/als-lights.xml
@@ -59,4 +59,30 @@
         </output>
     </logic>
 
+    <filter>
+        <name>Instruments Lighting</name>
+        <type>gain</type>
+        <input>
+            <condition>
+                <and>
+                    <less-than>
+                        <property>/systems/electrical/outputs/instrument-lights</property>
+                        <value>31.5</value>
+                    </less-than>
+                    <greater-than>
+                        <property>/systems/electrical/outputs/instrument-lights</property>
+                        <value>20.0</value>
+                    </greater-than>
+                </and>
+            </condition>
+            <property>/controls/lighting/instruments-norm</property>
+        </input>
+        <input>
+            <value>0.0</value>
+        </input>
+        <output>
+            <property>/sim/model/material/instruments/factor</property>
+        </output>
+    </filter>
+
 </PropertyList>


### PR DESCRIPTION
Fixes #103

Some (parts of) instruments do not make use of `/sim/model/material/instruments/factor` (but this is a separate issue):

![fgfs-screen-016](https://cloud.githubusercontent.com/assets/3361585/8022356/c63c6c04-0ccb-11e5-81d1-de8abe11d124.png)

Someone who can edit `<animation>` parts of XML files of the instruments should add `/sim/model/material/instruments/factor` to these files.