### PR TITLE
MP wake effects

### DIFF
--- a/Models/Effects/pontoon/left-spray.xml
+++ b/Models/Effects/pontoon/left-spray.xml
@@ -2,27 +2,40 @@
 
 <PropertyList>
 
+	<params>
+        <!-- IMPORTANT: int properties 14 to 19, both included, are reserved for the immat system. Do not use them! -->
+		<ground_solid>
+			<property>sim/multiplay/generic/int[23]</property>
+		</ground_solid>
+		<groundspeed_kt>
+			<property>sim/multiplay/generic/float[6]</property>
+		</groundspeed_kt>
+		<hydro_active_norm>
+			<property>sim/multiplay/generic/float[7]</property>
+		</hydro_active_norm>
+    </params>
+
     <particlesystem>
         <name>left-float</name>
         <texture>spray.png</texture>
         <emissive>false</emissive>
         <lighting>false</lighting>
-		
-        <condition>
-            <and>
-				<not>
-					<property>fdm/jsbsim/ground/solid</property>
-				</not>
-                <greater-than>
-                    <property>velocities/groundspeed-kt</property>
-                    <value>6</value>
-                </greater-than>
-		<greater-than>
-                    <property>/fdm/jsbsim/hydro/active-norm</property>
-                    <value>0</value>
-		</greater-than>
-            </and>
-        </condition>
+
+	<condition>
+		<and>
+			<not>
+				<property alias="/params/ground_solid/property"/>
+			</not>
+			<greater-than>
+				<property alias="/params/hydro_active_norm/property"/>
+				<value>0</value>
+			</greater-than>
+			<greater-than>
+				<property alias="/params/groundspeed_kt/property"/>
+				<value>6</value>
+			</greater-than>
+		</and>
+	</condition>
 
         <attach>world</attach>
 

--- a/Models/Effects/pontoon/left-spray.xml
+++ b/Models/Effects/pontoon/left-spray.xml
@@ -4,15 +4,9 @@
 
 	<params>
         <!-- IMPORTANT: int properties 14 to 19, both included, are reserved for the immat system. Do not use them! -->
-		<ground_solid>
-			<property>sim/multiplay/generic/int[23]</property>
-		</ground_solid>
-		<groundspeed_kt>
+		<sprake_wake_speed_kt>
 			<property>sim/multiplay/generic/float[6]</property>
-		</groundspeed_kt>
-		<hydro_active_norm>
-			<property>sim/multiplay/generic/float[7]</property>
-		</hydro_active_norm>
+		</sprake_wake_speed_kt>
     </params>
 
     <particlesystem>
@@ -22,19 +16,10 @@
         <lighting>false</lighting>
 
 	<condition>
-		<and>
-			<not>
-				<property alias="/params/ground_solid/property"/>
-			</not>
-			<greater-than>
-				<property alias="/params/hydro_active_norm/property"/>
-				<value>0</value>
-			</greater-than>
-			<greater-than>
-				<property alias="/params/groundspeed_kt/property"/>
-				<value>6</value>
-			</greater-than>
-		</and>
+		<greater-than>
+			<property alias="/params/sprake_wake_speed_kt/property"/>
+			<value>6</value>
+		</greater-than>
 	</condition>
 
         <attach>world</attach>

--- a/Models/Effects/pontoon/left-wake.xml
+++ b/Models/Effects/pontoon/left-wake.xml
@@ -4,15 +4,9 @@
 
 	<params>
         <!-- IMPORTANT: int properties 14 to 19, both included, are reserved for the immat system. Do not use them! -->
-		<ground_solid>
-			<property>sim/multiplay/generic/int[23]</property>
-		</ground_solid>
-		<groundspeed_kt>
+		<sprake_wake_speed_kt>
 			<property>sim/multiplay/generic/float[6]</property>
-		</groundspeed_kt>
-		<hydro_active_norm>
-			<property>sim/multiplay/generic/float[7]</property>
-		</hydro_active_norm>
+		</sprake_wake_speed_kt>
     </params>
 
   <particlesystem>
@@ -25,23 +19,14 @@
 
 	<condition>
 		<and>
-			<not>
-				<property alias="/params/ground_solid/property"/>
-			</not>
 			<greater-than>
-				<property alias="/params/hydro_active_norm/property"/>
-				<value>0</value>
-			</greater-than>
-			<greater-than>
-				<property alias="/params/groundspeed_kt/property"/>
+				<property alias="/params/sprake_wake_speed_kt/property"/>
 				<value>10</value>
 			</greater-than>
-			<not>
-			  <greater-than>
-				<property alias="/params/groundspeed_kt/property"/>
-				<value>20</value>
-			  </greater-than>
-			</not>
+			<less-than>
+				<property alias="/params/sprake_wake_speed_kt/property"/>
+			    <value>20</value>
+			</less-than>
 		</and>
 	</condition>
 
@@ -57,7 +42,7 @@
       <phi-min-deg>-1.5</phi-min-deg>
       <phi-max-deg>1.5</phi-max-deg>
       <speed-mps>
-        <property>instrumentation/airspeed-indicator/indicated-speed-kt</property>
+        <property alias="/params/sprake_wake_speed_kt/property"/>
         <value>10</value>
         <spread>2.5</spread>
       </speed-mps>
@@ -73,7 +58,7 @@
 
     <counter>
       <particles-per-sec>
-        <property>instrumentation/airspeed-indicator/indicated-speed-kt</property>
+        <property alias="/params/sprake_wake_speed_kt/property"/>
         <factor>15</factor>
         <spread>0</spread>
       </particles-per-sec>

--- a/Models/Effects/pontoon/left-wake.xml
+++ b/Models/Effects/pontoon/left-wake.xml
@@ -2,6 +2,19 @@
 
 <PropertyList>
 
+	<params>
+        <!-- IMPORTANT: int properties 14 to 19, both included, are reserved for the immat system. Do not use them! -->
+		<ground_solid>
+			<property>sim/multiplay/generic/int[23]</property>
+		</ground_solid>
+		<groundspeed_kt>
+			<property>sim/multiplay/generic/float[6]</property>
+		</groundspeed_kt>
+		<hydro_active_norm>
+			<property>sim/multiplay/generic/float[7]</property>
+		</hydro_active_norm>
+    </params>
+
   <particlesystem>
     <name>right-wake</name>
 
@@ -9,28 +22,28 @@
 
     <emissive>false</emissive>
     <lighting>true</lighting>
-	
-    <condition>
-            <and>
-				<not>
-					<property>fdm/jsbsim/ground/solid</property>
-				</not>
-                <greater-than>
-                    <property>velocities/groundspeed-kt</property>
-                    <value>10</value>
-                </greater-than>
-				<not>
-                  <greater-than>
-                    <property>velocities/groundspeed-kt</property>
-                    <value>20</value>
-                  </greater-than>
-				</not>
-		<greater-than>
-                    <property>/fdm/jsbsim/hydro/active-norm</property>
-                    <value>0</value>
-		</greater-than>
-            </and>
-        </condition>
+
+	<condition>
+		<and>
+			<not>
+				<property alias="/params/ground_solid/property"/>
+			</not>
+			<greater-than>
+				<property alias="/params/hydro_active_norm/property"/>
+				<value>0</value>
+			</greater-than>
+			<greater-than>
+				<property alias="/params/groundspeed_kt/property"/>
+				<value>10</value>
+			</greater-than>
+			<not>
+			  <greater-than>
+				<property alias="/params/groundspeed_kt/property"/>
+				<value>20</value>
+			  </greater-than>
+			</not>
+		</and>
+	</condition>
 
     <attach>world</attach>
 

--- a/Models/Effects/pontoon/middle-wake.xml
+++ b/Models/Effects/pontoon/middle-wake.xml
@@ -2,6 +2,19 @@
 
 <PropertyList>
 
+	<params>
+        <!-- IMPORTANT: int properties 14 to 19, both included, are reserved for the immat system. Do not use them! -->
+		<ground_solid>
+			<property>sim/multiplay/generic/int[23]</property>
+		</ground_solid>
+		<groundspeed_kt>
+			<property>sim/multiplay/generic/float[6]</property>
+		</groundspeed_kt>
+		<hydro_active_norm>
+			<property>sim/multiplay/generic/float[7]</property>
+		</hydro_active_norm>
+    </params>
+
   <particlesystem>
     <name>middle-wake</name>
 
@@ -13,16 +26,16 @@
 	<condition>
 		<and>
 			<not>
-				<property>fdm/jsbsim/ground/solid</property>
+				<property alias="/params/ground_solid/property"/>
 			</not>
 			<greater-than>
-				<property>velocities/groundspeed-kt</property>
+				<property alias="/params/hydro_active_norm/property"/>
+				<value>0</value>
+			</greater-than>
+			<greater-than>
+				<property alias="/params/groundspeed_kt/property"/>
 				<value>15</value>
 			</greater-than>
-		  <greater-than>
-                    <property>/fdm/jsbsim/hydro/active-norm</property>
-                    <value>0</value>
-		  </greater-than>
 		</and>
 	</condition>
 

--- a/Models/Effects/pontoon/middle-wake.xml
+++ b/Models/Effects/pontoon/middle-wake.xml
@@ -4,15 +4,9 @@
 
 	<params>
         <!-- IMPORTANT: int properties 14 to 19, both included, are reserved for the immat system. Do not use them! -->
-		<ground_solid>
-			<property>sim/multiplay/generic/int[23]</property>
-		</ground_solid>
-		<groundspeed_kt>
+		<sprake_wake_speed_kt>
 			<property>sim/multiplay/generic/float[6]</property>
-		</groundspeed_kt>
-		<hydro_active_norm>
-			<property>sim/multiplay/generic/float[7]</property>
-		</hydro_active_norm>
+		</sprake_wake_speed_kt>
     </params>
 
   <particlesystem>
@@ -24,19 +18,10 @@
     <lighting>true</lighting>
 
 	<condition>
-		<and>
-			<not>
-				<property alias="/params/ground_solid/property"/>
-			</not>
-			<greater-than>
-				<property alias="/params/hydro_active_norm/property"/>
-				<value>0</value>
-			</greater-than>
-			<greater-than>
-				<property alias="/params/groundspeed_kt/property"/>
-				<value>15</value>
-			</greater-than>
-		</and>
+		<greater-than>
+			<property alias="/params/sprake_wake_speed_kt/property"/>
+			<value>15</value>
+		</greater-than>
 	</condition>
 
     <attach>world</attach>
@@ -51,7 +36,7 @@
       <phi-min-deg>-10</phi-min-deg>
       <phi-max-deg>10</phi-max-deg>
       <speed-mps>
-        <property>instrumentation/airspeed-indicator/indicated-speed-kt</property>
+        <property alias="/params/sprake_wake_speed_kt/property"/>
         <value>10</value>
         <spread>2.5</spread>
       </speed-mps>
@@ -67,7 +52,7 @@
 
     <counter>
       <particles-per-sec>
-        <property>instrumentation/airspeed-indicator/indicated-speed-kt</property>
+        <property alias="/params/sprake_wake_speed_kt/property"/>
         <factor>15</factor>
         <spread>0</spread>
       </particles-per-sec>

--- a/Models/Effects/pontoon/right-spray.xml
+++ b/Models/Effects/pontoon/right-spray.xml
@@ -2,27 +2,40 @@
 
 <PropertyList>
 
+	<params>
+        <!-- IMPORTANT: int properties 14 to 19, both included, are reserved for the immat system. Do not use them! -->
+		<ground_solid>
+			<property>sim/multiplay/generic/int[23]</property>
+		</ground_solid>
+		<groundspeed_kt>
+			<property>sim/multiplay/generic/float[6]</property>
+		</groundspeed_kt>
+		<hydro_active_norm>
+			<property>sim/multiplay/generic/float[7]</property>
+		</hydro_active_norm>
+    </params>
+
     <particlesystem>
         <name>right-float</name>
         <texture>spray.png</texture>
         <emissive>false</emissive>
         <lighting>false</lighting>
 
-        <condition>
-            <and>
-				<not>
-					<property>fdm/jsbsim/ground/solid</property>
-				</not>
-                <greater-than>
-                    <property>velocities/groundspeed-kt</property>
-                    <value>6</value>
-                </greater-than>
-		<greater-than>
-                    <property>/fdm/jsbsim/hydro/active-norm</property>
-                    <value>0</value>
-		</greater-than>
-            </and>
-        </condition>
+	<condition>
+		<and>
+			<not>
+				<property alias="/params/ground_solid/property"/>
+			</not>
+			<greater-than>
+				<property alias="/params/hydro_active_norm/property"/>
+				<value>0</value>
+			</greater-than>
+			<greater-than>
+				<property alias="/params/groundspeed_kt/property"/>
+				<value>6</value>
+			</greater-than>
+		</and>
+	</condition>
 
         <attach>world</attach>
 

--- a/Models/Effects/pontoon/right-spray.xml
+++ b/Models/Effects/pontoon/right-spray.xml
@@ -4,15 +4,9 @@
 
 	<params>
         <!-- IMPORTANT: int properties 14 to 19, both included, are reserved for the immat system. Do not use them! -->
-		<ground_solid>
-			<property>sim/multiplay/generic/int[23]</property>
-		</ground_solid>
-		<groundspeed_kt>
+		<sprake_wake_speed_kt>
 			<property>sim/multiplay/generic/float[6]</property>
-		</groundspeed_kt>
-		<hydro_active_norm>
-			<property>sim/multiplay/generic/float[7]</property>
-		</hydro_active_norm>
+		</sprake_wake_speed_kt>
     </params>
 
     <particlesystem>
@@ -22,19 +16,10 @@
         <lighting>false</lighting>
 
 	<condition>
-		<and>
-			<not>
-				<property alias="/params/ground_solid/property"/>
-			</not>
-			<greater-than>
-				<property alias="/params/hydro_active_norm/property"/>
-				<value>0</value>
-			</greater-than>
-			<greater-than>
-				<property alias="/params/groundspeed_kt/property"/>
-				<value>6</value>
-			</greater-than>
-		</and>
+		<greater-than>
+			<property alias="/params/sprake_wake_speed_kt/property"/>
+			<value>6</value>
+		</greater-than>
 	</condition>
 
         <attach>world</attach>

--- a/Models/Effects/pontoon/right-wake.xml
+++ b/Models/Effects/pontoon/right-wake.xml
@@ -2,6 +2,19 @@
 
 <PropertyList>
 
+	<params>
+        <!-- IMPORTANT: int properties 14 to 19, both included, are reserved for the immat system. Do not use them! -->
+		<ground_solid>
+			<property>sim/multiplay/generic/int[23]</property>
+		</ground_solid>
+		<groundspeed_kt>
+			<property>sim/multiplay/generic/float[6]</property>
+		</groundspeed_kt>
+		<hydro_active_norm>
+			<property>sim/multiplay/generic/float[7]</property>
+		</hydro_active_norm>
+    </params>
+
   <particlesystem>
     <name>right-wake</name>
 
@@ -13,22 +26,22 @@
 	<condition>
 		<and>
 			<not>
-				<property>fdm/jsbsim/ground/solid</property>
+				<property alias="/params/ground_solid/property"/>
 			</not>
 			<greater-than>
-				<property>velocities/groundspeed-kt</property>
+				<property alias="/params/hydro_active_norm/property"/>
+				<value>0</value>
+			</greater-than>
+			<greater-than>
+				<property alias="/params/groundspeed_kt/property"/>
 				<value>10</value>
 			</greater-than>
 			<not>
-                  <greater-than>
-                    <property>velocities/groundspeed-kt</property>
-                    <value>20</value>
-                  </greater-than>
-				</not>
-		  <greater-than>
-                    <property>/fdm/jsbsim/hydro/active-norm</property>
-                    <value>0</value>
-		  </greater-than>
+			  <greater-than>
+				<property alias="/params/groundspeed_kt/property"/>
+				<value>20</value>
+			  </greater-than>
+			</not>
 		</and>
 	</condition>
 

--- a/Models/Effects/pontoon/right-wake.xml
+++ b/Models/Effects/pontoon/right-wake.xml
@@ -4,15 +4,9 @@
 
 	<params>
         <!-- IMPORTANT: int properties 14 to 19, both included, are reserved for the immat system. Do not use them! -->
-		<ground_solid>
-			<property>sim/multiplay/generic/int[23]</property>
-		</ground_solid>
-		<groundspeed_kt>
+		<sprake_wake_speed_kt>
 			<property>sim/multiplay/generic/float[6]</property>
-		</groundspeed_kt>
-		<hydro_active_norm>
-			<property>sim/multiplay/generic/float[7]</property>
-		</hydro_active_norm>
+		</sprake_wake_speed_kt>
     </params>
 
   <particlesystem>
@@ -25,23 +19,14 @@
 
 	<condition>
 		<and>
-			<not>
-				<property alias="/params/ground_solid/property"/>
-			</not>
 			<greater-than>
-				<property alias="/params/hydro_active_norm/property"/>
-				<value>0</value>
-			</greater-than>
-			<greater-than>
-				<property alias="/params/groundspeed_kt/property"/>
+				<property alias="/params/sprake_wake_speed_kt/property"/>
 				<value>10</value>
 			</greater-than>
-			<not>
-			  <greater-than>
-				<property alias="/params/groundspeed_kt/property"/>
+			<less-than>
+				<property alias="/params/sprake_wake_speed_kt/property"/>
 				<value>20</value>
-			  </greater-than>
-			</not>
+			</less-than>
 		</and>
 	</condition>
 
@@ -57,7 +42,7 @@
       <phi-min-deg>-1.5</phi-min-deg>
       <phi-max-deg>1.5</phi-max-deg>
       <speed-mps>
-        <property>instrumentation/airspeed-indicator/indicated-speed-kt</property>
+        <property alias="/params/sprake_wake_speed_kt/property"/>
         <value>10</value>
         <spread>2.5</spread>
       </speed-mps>
@@ -73,7 +58,7 @@
 
     <counter>
       <particles-per-sec>
-        <property>instrumentation/airspeed-indicator/indicated-speed-kt</property>
+        <property alias="/params/sprake_wake_speed_kt/property"/>
         <factor>15</factor>
         <spread>0</spread>
       </particles-per-sec>

--- a/Systems/c172p-hydrodynamics.xml
+++ b/Systems/c172p-hydrodynamics.xml
@@ -91,6 +91,21 @@
     </clipto>
   </fcs_function>
 
+  <fcs_function name="hydro/spray-wake-speed-kt">
+    <function>
+        <product>
+            <not>
+                <property>/fdm/jsbsim/ground/solid</property>
+            </not>
+            <gt>
+                <property>hydro/active-norm</property>
+                <value>0.0</value>
+            </gt>
+            <property>/velocities/groundspeed-kt</property>
+        </product>
+    </function>
+  </fcs_function>
+
  </channel>
 
  <channel name="Common coefficients">

--- a/Systems/flight-recorder/components/effects.xml
+++ b/Systems/flight-recorder/components/effects.xml
@@ -64,7 +64,7 @@
     <!-- Pontoon wakes -->
     <signal>
         <type>float</type>
-        <property type="string">/fdm/jsbsim/hydro/active-norm</property>
+        <property type="string">/fdm/jsbsim/hydro/spray-wake-speed-kt-actual</property>
     </signal>
 
 </PropertyList>

--- a/Systems/gearAGL.xml
+++ b/Systems/gearAGL.xml
@@ -2,6 +2,7 @@
 <!-- (c) 2015, wlbragg. http://forum.flightgear.org/viewtopic.php?f=4&t=25157&start=75#p232085
 Under the GPL. Used by shadows under ALS -->
 <PropertyList>
+
 	<filter>
       <type>gain</type>
       <gain>0.3048</gain>
@@ -9,6 +10,7 @@ Under the GPL. Used by shadows under ALS -->
       <reference>-.75</reference>
 	  <output>/position/gear-agl-m</output>
    </filter>
+
    <filter>
       <type>gain</type>
       <gain>0.3048</gain>
@@ -16,4 +18,27 @@ Under the GPL. Used by shadows under ALS -->
       <reference>1.0</reference>
       <output>/position/altitude-agl-m</output>
    </filter>
+
+    <!-- This filter is used to passthrough a value in non-replay mode.
+         In replay mode, the value from the flight recorder is used.
+         This filter is needed because JSBSim wins over the flight recorder.
+    -->
+    <filter>
+        <name>Spray and Wakes Effect for Pontoons</name>
+        <type>gain</type>
+        <enable>
+            <condition>
+                <not>
+                    <property>/sim/freeze/replay-state</property>
+                </not>
+            </condition>
+        </enable>
+        <input>
+            <property>/fdm/jsbsim/hydro/spray-wake-speed-kt</property>
+        </input>
+        <output>
+            <property>/fdm/jsbsim/hydro/spray-wake-speed-kt-actual</property>
+        </output>
+    </filter>
+
 </PropertyList>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -212,10 +212,14 @@ Many files from the original c172p directory are included in this file.
         <float n="0" alias="/sim/model/door-positions/rightDoor/position-norm"/>
         <float n="1" alias="/sim/model/door-positions/leftDoor/position-norm"/>
         <float n="2" alias="/sim/model/door-positions/baggageDoor/position-norm"/>
+		<float n="3" alias="/systems/electrical/outputs/nav-lights"/>
+        <float n="4" alias="/systems/electrical/outputs/taxi-light"/>
+        <float n="5" alias="/systems/electrical/outputs/landing-lights"/>
+		<float n="6" alias="/velocities/groundspeed-kt"/>
+		<float n="7" alias="/fdm/jsbsim/hydro/active-norm"/>
 
         <int n="1" alias="/sim/model/c172p/lighting/beacon-top/state"/>
         <int n="2" alias="/sim/model/c172p/lighting/strobes/state"/>
-        
         <int n="3" alias="/fdm/jsbsim/crash"/>
         <int n="4" alias="/fdm/jsbsim/contact/unit[4]/broken"/>
         <int n="5" alias="/fdm/jsbsim/contact/unit[5]/broken"/>
@@ -231,10 +235,7 @@ Many files from the original c172p directory are included in this file.
 		<int n="20" alias="/fdm/jsbsim/wing-both/broken"/>
 		<int n="21" alias="/fdm/jsbsim/wing-damage/left-wing"/>
 		<int n="22" alias="/fdm/jsbsim/wing-damage/right-wing"/>
-
-        <float n="3" alias="/systems/electrical/outputs/nav-lights"/>
-        <float n="4" alias="/systems/electrical/outputs/taxi-light"/>
-        <float n="5" alias="/systems/electrical/outputs/landing-lights"/>
+		<int n="23" alias="/fdm/jsbsim/ground/solid"/>
       </generic>
   </multiplay>
 

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -215,8 +215,7 @@ Many files from the original c172p directory are included in this file.
 		<float n="3" alias="/systems/electrical/outputs/nav-lights"/>
         <float n="4" alias="/systems/electrical/outputs/taxi-light"/>
         <float n="5" alias="/systems/electrical/outputs/landing-lights"/>
-		<float n="6" alias="/velocities/groundspeed-kt"/>
-		<float n="7" alias="/fdm/jsbsim/hydro/active-norm"/>
+		<float n="6" alias="/fdm/jsbsim/hydro/spray-wake-speed-kt"/>
 
         <int n="1" alias="/sim/model/c172p/lighting/beacon-top/state"/>
         <int n="2" alias="/sim/model/c172p/lighting/strobes/state"/>
@@ -235,7 +234,6 @@ Many files from the original c172p directory are included in this file.
 		<int n="20" alias="/fdm/jsbsim/wing-both/broken"/>
 		<int n="21" alias="/fdm/jsbsim/wing-damage/left-wing"/>
 		<int n="22" alias="/fdm/jsbsim/wing-damage/right-wing"/>
-		<int n="23" alias="/fdm/jsbsim/ground/solid"/>
       </generic>
   </multiplay>
 

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -215,7 +215,7 @@ Many files from the original c172p directory are included in this file.
 		<float n="3" alias="/systems/electrical/outputs/nav-lights"/>
         <float n="4" alias="/systems/electrical/outputs/taxi-light"/>
         <float n="5" alias="/systems/electrical/outputs/landing-lights"/>
-		<float n="6" alias="/fdm/jsbsim/hydro/spray-wake-speed-kt"/>
+		<float n="6" alias="/fdm/jsbsim/hydro/spray-wake-speed-kt-actual"/>
 
         <int n="1" alias="/sim/model/c172p/lighting/beacon-top/state"/>
         <int n="2" alias="/sim/model/c172p/lighting/strobes/state"/>


### PR DESCRIPTION
I made a property rule, everything worked perfectly with it except over MP. All the generic params looked correct but there just wasn't any wake. So I decided to do it with all the aliases. However as it turns out it was only going to save one alias because I needed groundspeed_kt separate anyway or I would have had to make a bunch of different prop rules and an alias for each which put us right back to where we were anyway. Look at the wake, spray, middle files, they all take different  groundspeed_kt params so it needed to be stand alone. That only left hydro/active-norm and ground/solid of which I also tried a prop rule fro the two. Again, locally everything worked fine, but not over MP. So we didn't save "one" alias. We can try to refactor later, maybe something will stand out that is causing the problem.  I honestly don't remember where this left off for recorder. I think it still needs ground/solid added to it. I'll look at that in the morning along with pontoon MP ground effects. This shouldn't have taken anywhere near as long as it did to finish, but testing MP is difficult especially when it doesn't want to cooperate.