### PR TITLE
Fix showing "Transponder" label without requiring Ctrl+c

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -1790,6 +1790,7 @@
     <object-name>LabelAltimeter</object-name>
     <object-name>LabelBatteryGauge</object-name>
     <object-name>LabelAutopilot</object-name>
+    <object-name>LabelTransponder</object-name>
     <object-name>LabelDME</object-name>
     <object-name>LabelTurn</object-name>
     <object-name>LabelVSI</object-name>


### PR DESCRIPTION
Fixes #286 