### PR TITLE
Bug 80

### DIFF
--- a/Models/Interior/Panel/Buttons/breakers/breakers.xml
+++ b/Models/Interior/Panel/Buttons/breakers/breakers.xml
@@ -456,7 +456,7 @@
       <binding>
         <command>set-tooltip</command>
         <tooltip-id>radio1_breaker</tooltip-id>
-        <label>Radio breaker: %s</label>
+        <label>Audio panel breaker: %s</label>
         <mapping>on-off</mapping>
         <property>/controls/circuit-breakers/radio1</property>
       </binding>

--- a/Models/Interior/Panel/Instruments/kma20/kma20.xml
+++ b/Models/Interior/Panel/Instruments/kma20/kma20.xml
@@ -26,6 +26,8 @@
   -->
 
   <params>
+    <power>/systems/electrical/outputs/audio-panel[0]</power>
+
     <outer>instrumentation/marker-beacon/outer</outer>
     <middle>instrumentation/marker-beacon/middle</middle>
     <inner>instrumentation/marker-beacon/inner</inner>
@@ -96,6 +98,18 @@
   <animation>
     <type>material</type>
     <object-name>O</object-name>
+    <condition>
+        <and>
+            <less-than>
+                <property alias="/params/power"/>
+                <value>31.5</value>
+            </less-than>
+            <greater-than>
+                <property alias="/params/power"/>
+                <value>20.0</value>
+            </greater-than>
+        </and>
+    </condition>
     <emission>
       <red>1.0</red>
       <green>1.0</green>
@@ -108,6 +122,18 @@
   <animation>
     <type>material</type>
     <object-name>M</object-name>
+    <condition>
+        <and>
+            <less-than>
+                <property alias="/params/power"/>
+                <value>31.5</value>
+            </less-than>
+            <greater-than>
+                <property alias="/params/power"/>
+                <value>20.0</value>
+            </greater-than>
+        </and>
+    </condition>
     <emission>
       <red>1.0</red>
       <green>1.0</green>
@@ -120,6 +146,18 @@
   <animation>
     <type>material</type>
     <object-name>A</object-name>
+    <condition>
+        <and>
+            <less-than>
+                <property alias="/params/power"/>
+                <value>31.5</value>
+            </less-than>
+            <greater-than>
+                <property alias="/params/power"/>
+                <value>20.0</value>
+            </greater-than>
+        </and>
+    </condition>
     <emission>
       <red>1.0</red>
       <green>1.0</green>


### PR DESCRIPTION
Fixes bug with the marker beacons test switch in the audio panel in #80. Also renamed the tooltip because "Radio" is confusing when the circuit breaker is connected to the audio panel instead.

![fgfs-screen-085](https://cloud.githubusercontent.com/assets/3361585/8155699/ec641216-1346-11e5-92a6-0f275d25af7e.png)
![fgfs-screen-086](https://cloud.githubusercontent.com/assets/3361585/8155700/ec681816-1346-11e5-9520-9e1b6dde1c22.png)
