### PR TITLE
Corrected best glide speed for C172P

### DIFF
--- a/Tutorials/engine-failure.xml
+++ b/Tutorials/engine-failure.xml
@@ -7,7 +7,7 @@ The tutorial starts with you cruising at 3500ft over the hills of San Francisco.
     
 Glide the aircraft to the nearest airport and make a successful emergency landing. You must manage your altitude and fly a normal pattern from "abeam the numbers". Don't deploy flaps until you have the runway "made".
     
-The Cessna 172 glides at a ratio of 10:1 at a best glide speed of 90kts IAS. The glide ratio assumes no flaps and a "windmilling" propeller. If you fly any faster or slower, or have flaps deployed, the glide rate will be worse.
+The Cessna 172 glides at a ratio of 9:1 at a best glide speed of 65 kts IAS. The glide ratio assumes no flaps and a "windmilling" propeller. If you fly any faster or slower, or have flaps deployed, the glide rate will be worse.
     
 Both KSFO (San Francisco International) and KHAF (Half Moon Bay) are within glide distance. In real life, you would opt for the larger of the two airports, but for an extra challenge, try to land at KHAF.
   </description>
@@ -62,7 +62,7 @@ Both KSFO (San Francisco International) and KHAF (Half Moon Bay) are within glid
   </step>
   
   <step>
-    <message>Engine failure! Engine failure! Trim for a best glide speed of 90 knots.</message>
+    <message>Engine failure! Engine failure! Trim for a best glide speed of 65 knots.</message>
     <set>
       <property>/controls/engines/engine/starter</property>
       <value>false</value>
@@ -86,26 +86,26 @@ Both KSFO (San Francisco International) and KHAF (Half Moon Bay) are within glid
   </step>
   
   <step>
-    <message>Now look around and choose an airport, or emergency landing site. Stay at 90 knots.</message>
+    <message>Now look around and choose an airport, or emergency landing site. Stay at 65 knots.</message>
     <set>
       <property>/engines/engine/running</property>
       <value>false</value>
     </set>
     <error>
-      <message>You are too slow. You need to fly at 90 knots IAS for maximum glide.</message>
+      <message>You are too slow. You need to fly at 65 knots IAS for maximum glide.</message>
       <condition>
         <less-than>
           <property>/instrumentation/airspeed-indicator/indicated-speed-kt</property>
-          <value>88</value>
+          <value>62</value>
         </less-than>
       </condition>
     </error>
     <error>
-      <message>You are too fast. You need to fly at 90 knots IAS for maximum glide.</message>
+      <message>You are too fast. You need to fly at 65 knots IAS for maximum glide.</message>
       <condition>
         <greater-than>
           <property>/instrumentation/airspeed-indicator/indicated-speed-kt</property>
-          <value>92</value>
+          <value>69</value>
         </greater-than>
       </condition>
     </error>
@@ -123,26 +123,26 @@ Both KSFO (San Francisco International) and KHAF (Half Moon Bay) are within glid
   
   <step>
     <message>Start maneuvering towards your chosen emergency landing spot,
-      keeping your speed at 90 knots IAS.</message>
+      keeping your speed at 65 knots IAS.</message>
     <set>
       <property>/engines/engine/running</property>
       <value>false</value>
     </set>
     <error>
-      <message>You are too slow. You need to fly at 90 knots IAS for maximum glide.</message>
+      <message>You are too slow. You need to fly at 65 knots IAS for maximum glide.</message>
       <condition>
         <less-than>
           <property>/instrumentation/airspeed-indicator/indicated-speed-kt</property>
-          <value>88</value>
+          <value>62</value>
         </less-than>
       </condition>
     </error>
     <error>
-      <message>You are too fast. You need to fly at 90 knots IAS for maximum glide.</message>
+      <message>You are too fast. You need to fly at 65 knots IAS for maximum glide.</message>
       <condition>
         <greater-than>
           <property>/instrumentation/airspeed-indicator/indicated-speed-kt</property>
-          <value>92</value>
+          <value>69</value>
         </greater-than>
       </condition>
     </error>
@@ -166,20 +166,20 @@ Both KSFO (San Francisco International) and KHAF (Half Moon Bay) are within glid
       <value>false</value>
     </set>
     <error>
-      <message>You are too slow. You need to fly at 90 knots IAS for maximum glide.</message>
+      <message>You are too slow. You need to fly at 65 knots IAS for maximum glide.</message>
       <condition>
         <less-than>
           <property>/instrumentation/airspeed-indicator/indicated-speed-kt</property>
-          <value>88</value>
+          <value>62</value>
         </less-than>
       </condition>
     </error>
     <error>
-      <message>You are too fast. You need to fly at 90 knots IAS for maximum glide.</message>
+      <message>You are too fast. You need to fly at 65 knots IAS for maximum glide.</message>
       <condition>
         <greater-than>
           <property>/instrumentation/airspeed-indicator/indicated-speed-kt</property>
-          <value>92</value>
+          <value>69</value>
         </greater-than>
       </condition>
     </error>
@@ -211,7 +211,7 @@ Both KSFO (San Francisco International) and KHAF (Half Moon Bay) are within glid
   </step>
   
   <step>
-    <message>Stay a 90 knots for maximum glide. Only use flaps once the runway is "made".</message>
+    <message>Stay a 65 knots for maximum glide. Only use flaps once the runway is "made".</message>
     <error>
       <message>Engine failure is currently simulated by switching off the magnetos.
         Please switch them off again to continue the tutorial.</message>


### PR DESCRIPTION
Best glide speed for C172P according to Pilot Operating Handbook is 65 knots. Updated all the speeds to the tutorial.