### PR TITLE
Tuned the friction of the float contact points.

### DIFF
--- a/c172p.xml
+++ b/c172p.xml
@@ -336,8 +336,8 @@
             <y>-56.889</y>
             <z>38.5</z>
           </location>
-          <static_friction>0.8</static_friction>
-          <dynamic_friction>0.7</dynamic_friction>
+          <static_friction>0.6</static_friction>
+          <dynamic_friction>0.5</dynamic_friction>
           <spring_coeff unit="LBS/FT">10000.00 </spring_coeff>
           <damping_coeff unit="LBS/FT/SEC">2500.00 </damping_coeff>
         </contact>
@@ -347,8 +347,8 @@
             <y>56.889</y>
             <z>38.5</z>
           </location>
-          <static_friction>0.8</static_friction>
-          <dynamic_friction>0.7</dynamic_friction>
+          <static_friction>0.6</static_friction>
+          <dynamic_friction>0.5</dynamic_friction>
           <spring_coeff unit="LBS/FT">10000.00 </spring_coeff>
           <damping_coeff unit="LBS/FT/SEC">2500.00 </damping_coeff>
         </contact>
@@ -358,8 +358,8 @@
             <y>-56.889</y>
             <z>38.5</z>
           </location>
-          <static_friction>0.8</static_friction>
-          <dynamic_friction>0.7</dynamic_friction>
+          <static_friction>0.6</static_friction>
+          <dynamic_friction>0.5</dynamic_friction>
           <spring_coeff unit="LBS/FT">10000.00 </spring_coeff>
           <damping_coeff unit="LBS/FT/SEC">2500.00 </damping_coeff>
         </contact>
@@ -369,8 +369,8 @@
             <y>56.889</y>
             <z>38.5</z>
           </location>
-          <static_friction>0.8</static_friction>
-          <dynamic_friction>0.7</dynamic_friction>
+          <static_friction>0.6</static_friction>
+          <dynamic_friction>0.5</dynamic_friction>
           <spring_coeff unit="LBS/FT">10000.00 </spring_coeff>
           <damping_coeff unit="LBS/FT/SEC">2500.00 </damping_coeff>
         </contact>
@@ -380,8 +380,8 @@
             <y>-56.889</y>
             <z>38.5</z>
           </location>
-          <static_friction>0.8</static_friction>
-          <dynamic_friction>0.7</dynamic_friction>
+          <static_friction>0.6</static_friction>
+          <dynamic_friction>0.5</dynamic_friction>
           <spring_coeff unit="LBS/FT">10000.00 </spring_coeff>
           <damping_coeff unit="LBS/FT/SEC">2500.00 </damping_coeff>
         </contact>
@@ -391,8 +391,8 @@
             <y>56.889</y>
             <z>38.5</z>
           </location>
-          <static_friction>0.8</static_friction>
-          <dynamic_friction>0.7</dynamic_friction>
+          <static_friction>0.6</static_friction>
+          <dynamic_friction>0.5</dynamic_friction>
           <spring_coeff unit="LBS/FT">10000.00 </spring_coeff>
           <damping_coeff unit="LBS/FT/SEC">2500.00 </damping_coeff>
         </contact>


### PR DESCRIPTION
It is now possible to land on a concrete runway without nosing over as
the FAA seaplane operations handbook indicates should be possible without
severe damage. There is currently no damage modelled for this float
maltreatement but it could be modelled by increasing the float leak rate.

Signed-off-by: Anders Gidenstam <anders@gidenstam.org>