### PR TITLE
Set heading offset to 0 when toggling panel

### DIFF
--- a/c172-help.xml
+++ b/c172-help.xml
@@ -20,7 +20,7 @@
   <line>For checklists, see under Help->Aircraft Checklists</line>
   <line/>
   <line>To show the high resolution panel for a multi-</line>
-  <line>computer setup, press P and then c.</line>
+  <line>computer setup, press P.</line>
   <line/>
   <line>Takeoff: no flaps, full throttle, rotate at 55 KIAS</line>
   <line>Climbout: no flaps, full throttle, 80 KIAS</line>

--- a/c172p-keyboard.xml
+++ b/c172p-keyboard.xml
@@ -19,6 +19,20 @@
 
 <PropertyList>
 
+    <key n="80">
+        <name>P</name>
+        <desc>Toggle panel</desc>
+        <binding>
+            <command>property-toggle</command>
+            <property>/sim/panel/visibility</property>
+        </binding>
+        <binding>
+            <command>property-assign</command>
+            <property>/sim/current-view/heading-offset-deg</property>
+            <value type="double">0.0</value>
+        </binding>
+    </key>
+
     <key n="76">
         <name>L</name>
         <desc>Decrease Panel lighting</desc>


### PR DESCRIPTION
Fixes #338. See PR #340 for the buggyness of the P key binding.

The panel does not show itself if /sim/current-view/heading-offset-deg
is not 0. Therefore, add an additional <binding> to set it to 0.

You only need to press P, there is no need to press c. First time you press P you need to wait a little because FlightGear needs to load the panel.