### PR TITLE
flight recorder: Add rollspeed-ms of gear, water rudder, and stall horn

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -165,6 +165,7 @@
             <rear-right-position-norm>engines/engine[6]/n2</rear-right-position-norm>
             <rear-right-rollspeed-ms>engines/engine[6]/rpm</rear-right-rollspeed-ms>
         </gear-amphibious>
+        <water-rudder-norm>/controls/gear/water-rudder-down-actual</water-rudder-norm>
         <engine>
             <rpm>engines/engine[2]/rpm</rpm>
         </engine>
@@ -5830,7 +5831,7 @@
   <animation>
     <type>rotate</type>
     <object-name>RHrudder</object-name>
-    <property>controls/gear/water-rudder-down</property>
+    <property alias="/params/water-rudder-norm"/>
     <factor>90</factor>
     <center>
       <x-m>3.47</x-m>
@@ -5865,7 +5866,7 @@
   <animation>
     <type>rotate</type>
     <object-name>LHrudder</object-name>
-    <property>controls/gear/water-rudder-down</property>
+    <property alias="/params/water-rudder-norm"/>
     <factor>90</factor>
     <center>
       <x-m>3.47</x-m>

--- a/Systems/flight-recorder/components/gear-amphibious.xml
+++ b/Systems/flight-recorder/components/gear-amphibious.xml
@@ -12,12 +12,22 @@
     </signal>
     <signal>
         <type>float</type>
+        <property type="string">/gear/gear[19]/rollspeed-ms</property>
+    </signal>
+
+    <signal>
+        <type>float</type>
         <property type="string">/gear/gear[20]/compression-norm</property>
     </signal>
     <signal>
         <type>float</type>
         <property type="string">/gear/gear[20]/position-norm</property>
     </signal>
+    <signal>
+        <type>float</type>
+        <property type="string">/gear/gear[20]/rollspeed-ms</property>
+    </signal>
+
     <signal>
         <type>float</type>
         <property type="string">/gear/gear[21]/compression-norm</property>
@@ -28,11 +38,25 @@
     </signal>
     <signal>
         <type>float</type>
+        <property type="string">/gear/gear[21]/rollspeed-ms</property>
+    </signal>
+
+    <signal>
+        <type>float</type>
         <property type="string">/gear/gear[22]/compression-norm</property>
     </signal>
     <signal>
         <type>float</type>
         <property type="string">/gear/gear[22]/position-norm</property>
+    </signal>
+    <signal>
+        <type>float</type>
+        <property type="string">/gear/gear[22]/rollspeed-ms</property>
+    </signal>
+
+    <signal>
+        <type>float</type>
+        <property type="string">/controls/gear/water-rudder-down-actual</property>
     </signal>
 
 </PropertyList>

--- a/Systems/flight-recorder/components/systems-instruments.xml
+++ b/Systems/flight-recorder/components/systems-instruments.xml
@@ -102,4 +102,17 @@
         <property type="string">/environment/aircraft-effects/cabinairdewpointC</property>
     </signal>
 
+    <!-- ============================================================== -->
+    <!-- Stall Horn                                                     -->
+    <!-- ============================================================== -->
+
+    <signal>
+        <type>float</type>
+        <property type="string">/fdm/jsbsim/sounds/stall-horn-volume-actual</property>
+    </signal>
+    <signal>
+        <type>float</type>
+        <property type="string">/fdm/jsbsim/sounds/stall-horn-pitch-actual</property>
+    </signal>
+
 </PropertyList>

--- a/Systems/ground-effects.xml
+++ b/Systems/ground-effects.xml
@@ -18,10 +18,65 @@ Under the GPL. Used by shadows under ALS -->
       <output>/position/altitude-agl-m</output>
    </filter>
 
-    <!-- This filter is used to passthrough a value in non-replay mode.
+    <!-- These filters are used to passthrough a value in non-replay mode.
          In replay mode, the value from the flight recorder is used.
          This filter is needed because JSBSim wins over the flight recorder.
     -->
+
+    <filter>
+        <name>Stall Horn Volume</name>
+        <type>gain</type>
+        <enable>
+            <condition>
+                <not>
+                    <property>/sim/freeze/replay-state</property>
+                </not>
+            </condition>
+        </enable>
+        <input>
+            <property>/fdm/jsbsim/sounds/stall-horn-volume</property>
+        </input>
+        <output>
+            <property>/fdm/jsbsim/sounds/stall-horn-volume-actual</property>
+        </output>
+    </filter>
+
+    <filter>
+        <name>Stall Horn Pitch</name>
+        <type>gain</type>
+        <enable>
+            <condition>
+                <not>
+                    <property>/sim/freeze/replay-state</property>
+                </not>
+            </condition>
+        </enable>
+        <input>
+            <property>/fdm/jsbsim/sounds/stall-horn-pitch</property>
+        </input>
+        <output>
+            <property>/fdm/jsbsim/sounds/stall-horn-pitch-actual</property>
+        </output>
+    </filter>
+
+    <filter>
+        <name>Water Rudder Position</name>
+        <type>gain</type>
+        <enable>
+            <condition>
+                <not>
+                    <property>/sim/freeze/replay-state</property>
+                </not>
+            </condition>
+        </enable>
+        <input>
+            <property>/controls/gear/water-rudder-down</property>
+        </input>
+        <output>
+            <property>/controls/gear/water-rudder-down-actual</property>
+        </output>
+    </filter>
+
     <filter>
         <name>Spray and Wakes Effect for Pontoons</name>
         <type>gain</type>

--- a/c172-sound.xml
+++ b/c172-sound.xml
@@ -275,10 +275,10 @@
     <z>0.4831</z>
    </position>
    <volume>
-    <property>/fdm/jsbsim/sounds/stall-horn-volume</property>
+    <property>/fdm/jsbsim/sounds/stall-horn-volume-actual</property>
    </volume>
    <pitch>
-    <property>/fdm/jsbsim/sounds/stall-horn-pitch</property>
+    <property>/fdm/jsbsim/sounds/stall-horn-pitch-actual</property>
     <offset>0.0</offset>
    </pitch>
    <reference-dist>0.5</reference-dist>


### PR DESCRIPTION
Fixes #349 

* Toggle `/controls/gear/water-rudder` in Internal Properties window to lower/raise water rudder.
* Start engine and press Ctrl + u to test stall horn.