### PR TITLE
Bug 280

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -65,6 +65,19 @@
      setlistener(regnum_path, func (node) {
         set_registration_number(rplayer, node.getValue());
      }, 1, 0);
+
+     # Gear
+     rplayer.initNode("sim/multiplay/generic/int[6]", 0, "BOOL");
+     rplayer.initNode("sim/multiplay/generic/int[7]", 0, "BOOL");
+     rplayer.initNode("sim/multiplay/generic/int[8]", 0, "BOOL");
+
+     # Bush kit
+     rplayer.initNode("sim/multiplay/generic/int[9]", 0, "INT");
+
+     # Damage
+     rplayer.initNode("sim/multiplay/generic/int[14]", 0, "INT");
+     rplayer.initNode("sim/multiplay/generic/int[18]", 0, "INT");
+     rplayer.initNode("sim/multiplay/generic/int[19]", 0, "INT");
    </load>
 
    <unload>
@@ -102,7 +115,7 @@
             </baggage>
         </doors>
 		<crash>
-			<property>sim/multiplay/generic/int[3]</property>	
+			<property>sim/multiplay/generic/int[14]</property>
 		</crash>    
 		<gear_nose_broken>
 			<property>sim/multiplay/generic/int[6]</property>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -142,20 +142,7 @@
 			<property>sim/multiplay/generic/int[13]</property>
 		</pontoon_right_broken>
 
-        <!--
-            0    = normal
-            1    = broken
-            2, 3 = light/heavy damage
-
-            In the code below, if we need to check that a wing
-            is not damaged, we use <not-equals> with <value>0</value>.
-
-            If we need to check that a wing is not broken, we use
-            <not-equals> with <value>1</value>
-
-            If we want to check that a wing _is_ damaged, we use
-            <greater-than-equals> with <value>2</value>.
-        -->
+        <!-- 0 = normal, 1 = broken, 2 = damaged -->
 		<wing_left_damaged>
 			<property>sim/multiplay/generic/int[18]</property>
 		</wing_left_damaged>
@@ -3668,14 +3655,14 @@
    <object-name>landinglight2BD</object-name>
    <condition>
 		<and>
-            <greater-than-equals>
+            <equals>
 			    <property alias="/params/wing_left_damaged/property"/>
                 <value>2</value>
-            </greater-than-equals>
-            <greater-than-equals>
+            </equals>
+            <equals>
 			    <property alias="/params/wing_right_damaged/property"/>
                 <value>2</value>
-            </greater-than-equals>
+            </equals>
 			<not>
 			  <property alias="/params/crash/property"/>
 			</not>
@@ -3698,10 +3685,10 @@
    <object-name>landinglight2LD</object-name>
    <condition>
 	<and>
-        <greater-than-equals>
+        <equals>
 		    <property alias="/params/wing_left_damaged/property"/>
             <value>2</value>
-        </greater-than-equals>
+        </equals>
 		<equals>
 		    <property alias="/params/wing_right_damaged/property"/>
             <value>0</value>
@@ -3728,10 +3715,10 @@
    <object-name>landinglight2RD</object-name>
    <condition>
 	<and>
-        <greater-than-equals>
+        <equals>
 		    <property alias="/params/wing_right_damaged/property"/>
             <value>2</value>
-        </greater-than-equals>
+        </equals>
 		<equals>
 		    <property alias="/params/wing_left_damaged/property"/>
             <value>0</value>
@@ -3756,10 +3743,10 @@
 		    <property alias="/params/wing_left_damaged/property"/>
             <value>1</value>
         </equals>
-        <greater-than-equals>
+        <equals>
 		    <property alias="/params/wing_right_damaged/property"/>
             <value>2</value>
-        </greater-than-equals>
+        </equals>
 		<not>
 		  <property alias="/params/crash/property"/>
 		</not>
@@ -3783,10 +3770,10 @@
 		    <property alias="/params/wing_right_damaged/property"/>
             <value>1</value>
         </equals>
-        <greater-than-equals>
+        <equals>
 		    <property alias="/params/wing_left_damaged/property"/>
             <value>2</value>
-        </greater-than-equals>
+        </equals>
 		<not>
 		  <property alias="/params/crash/property"/>
 		</not>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -5437,9 +5437,7 @@
           <property>sim/current-view/name</property>
           <value>Walker Orbit View</value>
         </not-equals>
-		<not>
-          <property>sim/model/occupants</property>
-        </not>
+        <property>sim/model/occupants</property>
       </and>
     </condition>
   </animation>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -129,18 +129,14 @@
 		<bushkit>
 			<property>sim/multiplay/generic/int[9]</property>
 		</bushkit>
+
+        <!-- 0 = normal, 1 = broken, 2 = damaged -->
 		<pontoon_left_damaged>
 			<property>sim/multiplay/generic/int[10]</property>
 		</pontoon_left_damaged>
-		<pontoon_left_broken>
-			<property>sim/multiplay/generic/int[11]</property>
-		</pontoon_left_broken>
 		<pontoon_right_damaged>
-			<property>sim/multiplay/generic/int[12]</property>
+			<property>sim/multiplay/generic/int[11]</property>
 		</pontoon_right_damaged>
-		<pontoon_right_broken>
-			<property>sim/multiplay/generic/int[13]</property>
-		</pontoon_right_broken>
 
         <!-- 0 = normal, 1 = broken, 2 = damaged -->
 		<wing_left_damaged>
@@ -3526,15 +3522,19 @@
    <object-name>Propeller</object-name>
    <object-name>Propeller.Fast</object-name>
    <condition>
-	  <not>
-		<or>
+    <and>
+        <not>
 		  <property alias="/params/gear_nose_broken/property"/>
+        </not>
+        <equals>
 		  <property alias="/params/pontoon_left_damaged/property"/>
-		  <property alias="/params/pontoon_left_broken/property"/>
+          <value>0</value>
+        </equals>
+        <equals>
 		  <property alias="/params/pontoon_right_damaged/property"/>
-		  <property alias="/params/pontoon_right_broken/property"/>
-	    </or>
-	  </not>
+          <value>0</value>
+        </equals>
+    </and>
    </condition>
  </animation>
 
@@ -3545,10 +3545,14 @@
    <condition>
 	    <or>
 		    <property alias="/params/gear_nose_broken/property"/>
-		    <property alias="/params/pontoon_left_damaged/property"/>
-		    <property alias="/params/pontoon_left_broken/property"/>
-		    <property alias="/params/pontoon_right_damaged/property"/>
-		    <property alias="/params/pontoon_right_broken/property"/>
+            <not-equals>
+		        <property alias="/params/pontoon_left_damaged/property"/>
+                <value>0</value>
+            </not-equals>
+            <not-equals>
+		        <property alias="/params/pontoon_right_damaged/property"/>
+                <value>0</value>
+            </not-equals>
 		</or>
    </condition>
  </animation>
@@ -3842,12 +3846,10 @@
    <object-name>L-FloatC</object-name>
    <condition>
 	  <and>
-		<not>
+		<equals>
 			<property alias="/params/pontoon_left_damaged/property"/>
-		</not>
-		<not>
-			<property alias="/params/pontoon_left_broken/property"/>
-		</not>
+			<value>0</value>
+		</equals>
 		<equals>
 			<property alias="/params/bushkit/property"/>
 			<value>3</value>
@@ -3862,12 +3864,10 @@
    <object-name>R-FloatC</object-name>
    <condition>
 	  <and>
-		<not>
+		<equals>
 			<property alias="/params/pontoon_right_damaged/property"/>
-		</not>
-		<not>
-			<property alias="/params/pontoon_right_broken/property"/>
-		</not>
+            <value>0</value>
+		</equals>
 		<equals>
 			<property alias="/params/bushkit/property"/>
 			<value>3</value>
@@ -3890,12 +3890,10 @@
    <object-name>Lstrut.002</object-name>
    <condition>
 	  <and>
-		<not>
+		<equals>
 			<property alias="/params/pontoon_left_damaged/property"/>
-		</not>
-		<not>
-			<property alias="/params/pontoon_left_broken/property"/>
-		</not>
+			<value>0</value>
+		</equals>
 		<equals>
 			<property alias="/params/bushkit/property"/>
 			<value>4</value>
@@ -3918,12 +3916,10 @@
    <object-name>Rstrut.002</object-name>
    <condition>
 	  <and>
-		<not>
+		<equals>
 			<property alias="/params/pontoon_right_damaged/property"/>
-		</not>
-		<not>
-			<property alias="/params/pontoon_right_broken/property"/>
-		</not>
+            <value>0</value>
+		</equals>
 		<equals>
 			<property alias="/params/bushkit/property"/>
 			<value>4</value>
@@ -3938,12 +3934,10 @@
    <object-name>LHrudder</object-name>
    <condition>
 	  <and>
-		<not>
-		  <property alias="/params/pontoon_left_damaged/property"/>
-		</not>
-		<not>
-		  <property alias="/params/pontoon_left_broken/property"/>
-		</not>
+		<equals>
+		    <property alias="/params/pontoon_left_damaged/property"/>
+	        <value>0</value>
+		</equals>
 		<or>
 			<equals>
 			  <property alias="/params/bushkit/property"/>
@@ -3964,12 +3958,10 @@
    <object-name>RHrudder</object-name>
    <condition>
 	  <and>
-	    <not>
-		  <property alias="/params/pontoon_right_damaged/property"/>
-		</not>
-		<not>
-		  <property alias="/params/pontoon_right_broken/property"/>
-		</not>
+		<equals>
+		    <property alias="/params/pontoon_right_damaged/property"/>
+            <value>0</value>
+		</equals>
 		<or>
 			<equals>
 			  <property alias="/params/bushkit/property"/>
@@ -4009,10 +4001,10 @@
    <object-name>L-FloatCD</object-name>
    <condition>
 	  <and>
-	    <property alias="/params/pontoon_left_damaged/property"/>
-		<not>
-		  <property alias="/params/pontoon_left_broken/property"/>
-		</not>
+        <equals>
+	        <property alias="/params/pontoon_left_damaged/property"/>
+		    <value>2</value>
+        </equals>
 		<equals>
 		  <property alias="/params/bushkit/property"/>
 		  <value>3</value>
@@ -4027,10 +4019,10 @@
    <object-name>R-FloatCD</object-name>
    <condition>
 	  <and>
-	    <property alias="/params/pontoon_right_damaged/property"/>
-		<not>
-		  <property alias="/params/pontoon_right_broken/property"/>
-		</not>
+		<equals>
+	        <property alias="/params/pontoon_right_damaged/property"/>
+            <value>2</value>
+		</equals>
 		<equals>
 		  <property alias="/params/bushkit/property"/>
 		  <value>3</value>
@@ -4079,10 +4071,10 @@
    <object-name>LstrutOD.002</object-name>
    <condition>
 	  <and>
-	    <property alias="/params/pontoon_left_damaged/property"/>
-		<not>
-		  <property alias="/params/pontoon_left_broken/property"/>
-		</not>
+        <equals>
+	        <property alias="/params/pontoon_left_damaged/property"/>
+            <value>2</value>
+        </equals>
 		<equals>
 		  <property alias="/params/bushkit/property"/>
 		  <value>4</value>
@@ -4101,10 +4093,10 @@
    <object-name>RstrutOD.002</object-name>
    <condition>
 	  <and>
-	    <property alias="/params/pontoon_right_damaged/property"/>
-		<not>
-		  <property alias="/params/pontoon_right_broken/property"/>
-		</not>
+		<equals>
+	        <property alias="/params/pontoon_right_damaged/property"/>
+            <value>2</value>
+		</equals>
 		<equals>
 		  <property alias="/params/bushkit/property"/>
 		  <value>4</value>
@@ -4157,10 +4149,10 @@
    <object-name>LHrudderD</object-name>
    <condition>
 	  <and>
-	    <property alias="/params/pontoon_left_damaged/property"/>
-		<not>
-		  <property alias="/params/pontoon_left_broken/property"/>
-		</not>
+        <equals>
+	        <property alias="/params/pontoon_left_damaged/property"/>
+            <value>2</value>
+        </equals>
 		<or>
 			<equals>
 			  <property alias="/params/bushkit/property"/>
@@ -4181,10 +4173,10 @@
    <object-name>RHrudderD</object-name>
    <condition>
 	  <and>
-	    <property alias="/params/pontoon_right_damaged/property"/>
-		<not>
-		  <property alias="/params/pontoon_right_broken/property"/>
-		</not>
+        <equals>
+	        <property alias="/params/pontoon_right_damaged/property"/>
+            <value>2</value>
+        </equals>
 		<or>
 			<equals>
 			  <property alias="/params/bushkit/property"/>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -128,12 +128,28 @@
 		<pontoon_right_broken>
 			<property>sim/multiplay/generic/int[13]</property>
 		</pontoon_right_broken>
+
+        <!--
+            0    = normal
+            1    = broken
+            2, 3 = light/heavy damage
+
+            In the code below, if we need to check that a wing
+            is not damaged, we use <not-equals> with <value>0</value>.
+
+            If we need to check that a wing is not broken, we use
+            <not-equals> with <value>1</value>
+
+            If we want to check that a wing _is_ damaged, we use
+            <greater-than-equals> with <value>2</value>.
+        -->
 		<wing_left_damaged>
-			<property>sim/multiplay/generic/float[18]</property>
+			<property>sim/multiplay/generic/int[18]</property>
 		</wing_left_damaged>
 		<wing_right_damaged>
-			<property>sim/multiplay/generic/float[19]</property>
+			<property>sim/multiplay/generic/int[19]</property>
 		</wing_right_damaged>
+
         <gear>
             <left-rollspeed-ms>engines/engine[7]/n1</left-rollspeed-ms>
             <right-rollspeed-ms>engines/engine[7]/n2</right-rollspeed-ms>
@@ -3116,10 +3132,10 @@
    <property>surface-positions/left-aileron-pos-norm</property>
    <condition>
        <and>
-           <less-than>
+           <not-equals>
                <property alias="/params/wing_left_damaged/property"/>
-               <value>1.0</value>
-           </less-than>
+               <value>1</value>
+           </not-equals>
 	       <not>
 			     <property alias="/params/crash/property"/>
 	       </not>
@@ -3539,14 +3555,14 @@
    <object-name>flapsD</object-name>
    <condition>
       <or>
-          <greater-than>
+          <not-equals>
 		      <property alias="/params/wing_left_damaged/property"/>
-              <value>0.0</value>
-          </greater-than>
-          <greater-than>
+              <value>0</value>
+          </not-equals>
+          <not-equals>
 		      <property alias="/params/wing_right_damaged/property"/>
-              <value>0.0</value>
-          </greater-than>
+              <value>0</value>
+          </not-equals>
           <property alias="/params/crash/property"/>
       </or>
    </condition>
@@ -3570,11 +3586,11 @@
     <and>
 		<equals>
 		  <property alias="/params/wing_left_damaged/property"/>
-          <value>0.0</value>
+          <value>0</value>
 		</equals>
 		<equals>
 		  <property alias="/params/wing_right_damaged/property"/>
-          <value>0.0</value>
+          <value>0</value>
 		</equals>
         <not>
             <property alias="/params/crash/property"/>
@@ -3610,11 +3626,11 @@
 		<and>
             <equals>
 		        <property alias="/params/wing_left_damaged/property"/>
-                <value>1.0</value>
+                <value>1</value>
             </equals>
             <equals>
 	            <property alias="/params/wing_right_damaged/property"/>
-                <value>1.0</value>
+                <value>1</value>
             </equals>
 		</and>
 		<not>
@@ -3639,22 +3655,14 @@
    <object-name>landinglight2BD</object-name>
    <condition>
 		<and>
-            <greater-than>
+            <greater-than-equals>
 			    <property alias="/params/wing_left_damaged/property"/>
-                <value>0.0</value>
-            </greater-than>
-            <less-than>
-			    <property alias="/params/wing_left_damaged/property"/>
-                <value>1.0</value>
-            </less-than>
-            <greater-than>
+                <value>2</value>
+            </greater-than-equals>
+            <greater-than-equals>
 			    <property alias="/params/wing_right_damaged/property"/>
-                <value>0.0</value>
-            </greater-than>
-            <less-than>
-			    <property alias="/params/wing_right_damaged/property"/>
-                <value>1.0</value>
-            </less-than>
+                <value>2</value>
+            </greater-than-equals>
 			<not>
 			  <property alias="/params/crash/property"/>
 			</not>
@@ -3677,17 +3685,13 @@
    <object-name>landinglight2LD</object-name>
    <condition>
 	<and>
-        <greater-than>
+        <greater-than-equals>
 		    <property alias="/params/wing_left_damaged/property"/>
-            <value>0.0</value>
-        </greater-than>
-        <less-than>
-		    <property alias="/params/wing_left_damaged/property"/>
-            <value>1.0</value>
-        </less-than>
+            <value>2</value>
+        </greater-than-equals>
 		<equals>
 		    <property alias="/params/wing_right_damaged/property"/>
-            <value>0.0</value>
+            <value>0</value>
 		</equals>
 		<not>
 		  <property alias="/params/crash/property"/>
@@ -3711,17 +3715,13 @@
    <object-name>landinglight2RD</object-name>
    <condition>
 	<and>
-        <greater-than>
+        <greater-than-equals>
 		    <property alias="/params/wing_right_damaged/property"/>
-            <value>0.0</value>
-        </greater-than>
-        <less-than>
-		    <property alias="/params/wing_right_damaged/property"/>
-            <value>1.0</value>
-        </less-than>
+            <value>2</value>
+        </greater-than-equals>
 		<equals>
 		    <property alias="/params/wing_left_damaged/property"/>
-            <value>0.0</value>
+            <value>0</value>
 		</equals>
 		<not>
 		  <property alias="/params/crash/property"/>
@@ -3741,16 +3741,12 @@
 	<and>
         <equals>
 		    <property alias="/params/wing_left_damaged/property"/>
-            <value>1.0</value>
+            <value>1</value>
         </equals>
-        <greater-than>
+        <greater-than-equals>
 		    <property alias="/params/wing_right_damaged/property"/>
-            <value>0.0</value>
-        </greater-than>
-        <less-than>
-		    <property alias="/params/wing_right_damaged/property"/>
-            <value>1.0</value>
-        </less-than>
+            <value>2</value>
+        </greater-than-equals>
 		<not>
 		  <property alias="/params/crash/property"/>
 		</not>
@@ -3772,16 +3768,12 @@
 	  <and>
         <equals>
 		    <property alias="/params/wing_right_damaged/property"/>
-            <value>1.0</value>
+            <value>1</value>
         </equals>
-        <greater-than>
+        <greater-than-equals>
 		    <property alias="/params/wing_left_damaged/property"/>
-            <value>0.0</value>
-        </greater-than>
-        <less-than>
-		    <property alias="/params/wing_left_damaged/property"/>
-            <value>1.0</value>
-        </less-than>
+            <value>2</value>
+        </greater-than-equals>
 		<not>
 		  <property alias="/params/crash/property"/>
 		</not>
@@ -3800,11 +3792,11 @@
 	<and>
 		<equals>
 		    <property alias="/params/wing_left_damaged/property"/>
-            <value>1.0</value>
+            <value>1</value>
 		</equals>
 		<equals>
 		  <property alias="/params/wing_right_damaged/property"/>
-          <value>0.0</value>
+          <value>0</value>
 		</equals>
 		<not>
 		  <property alias="/params/crash/property"/>
@@ -3827,11 +3819,11 @@
 	<and>
 		<equals>
 		    <property alias="/params/wing_right_damaged/property"/>
-            <value>1.0</value>
+            <value>1</value>
 		</equals>
 		<equals>
 		    <property alias="/params/wing_left_damaged/property"/>
-            <value>0.0</value>
+            <value>0</value>
 		</equals>
 		<not>
 		  <property alias="/params/crash/property"/>
@@ -4829,7 +4821,7 @@
            <property alias="/params/lighting/strobes/property"/>
 	       <equals>
 	           <property alias="/params/wing_left_damaged/property"/>
-               <value>0.0</value>
+               <value>0</value>
 	       </equals>
 		   <not>
 	           <property alias="/params/crash/property"/>
@@ -4846,7 +4838,7 @@
            <property alias="/params/lighting/strobes/property"/>
 	       <equals>
 	           <property alias="/params/wing_right_damaged/property"/>
-               <value>0.0</value>
+               <value>0</value>
 	       </equals>
 		   <not>
 	           <property alias="/params/crash/property"/>
@@ -4861,10 +4853,10 @@
    <condition>
        <and>
            <property alias="/params/lighting/strobes/property"/>
-           <less-than>
+           <not-equals>
 		       <property alias="/params/wing_left_damaged/property"/>
-               <value>1.0</value>
-           </less-than>
+               <value>1</value>
+           </not-equals>
 		   <not>
 	           <property alias="/params/crash/property"/>
 	       </not>
@@ -4878,10 +4870,10 @@
    <condition>
        <and>
            <property alias="/params/lighting/strobes/property"/>
-           <less-than>
+           <not-equals>
 	           <property alias="/params/wing_right_damaged/property"/>
-               <value>1.0</value>
-           </less-than>
+               <value>1</value>
+           </not-equals>
 		   <not>
 	           <property alias="/params/crash/property"/>
 	       </not>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -3076,10 +3076,14 @@
    <object-name>navlight_leftD</object-name>
    <object-name>navlight_leftBD</object-name>
    <object-name>navlight_leftCollapse</object-name>
+   <object-name>navlight_leftDRB</object-name>
+   <object-name>navlight_leftGRB</object-name>
    <object-name>navlight_rightU</object-name>
    <object-name>navlight_rightD</object-name>
    <object-name>navlight_rightBD</object-name>
    <object-name>navlight_rightCollapse</object-name>
+   <object-name>navlight_rightDLB</object-name>
+   <object-name>navlight_rightGLB</object-name>
    <condition>
      <property alias="../../../params/lighting/navigation/property"/>
    </condition>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -104,12 +104,6 @@
 		<crash>
 			<property>sim/multiplay/generic/int[3]</property>	
 		</crash>    
-		<wing_left_broken>
-			<property>sim/multiplay/generic/int[4]</property>
-		</wing_left_broken>		
-		<wing_right_broken>
-			<property>sim/multiplay/generic/int[5]</property>
-		</wing_right_broken>		
 		<gear_nose_broken>
 			<property>sim/multiplay/generic/int[6]</property>
 		</gear_nose_broken>
@@ -134,14 +128,11 @@
 		<pontoon_right_broken>
 			<property>sim/multiplay/generic/int[13]</property>
 		</pontoon_right_broken>
-		<wing_both_broken>
-			<property>sim/multiplay/generic/int[14]</property>
-		</wing_both_broken>
 		<wing_left_damaged>
-			<property>sim/multiplay/generic/int[15]</property>
+			<property>sim/multiplay/generic/float[18]</property>
 		</wing_left_damaged>
 		<wing_right_damaged>
-			<property>sim/multiplay/generic/int[16]</property>
+			<property>sim/multiplay/generic/float[19]</property>
 		</wing_right_damaged>
         <gear>
             <left-rollspeed-ms>engines/engine[7]/n1</left-rollspeed-ms>
@@ -3125,9 +3116,10 @@
    <property>surface-positions/left-aileron-pos-norm</property>
    <condition>
        <and>
-           <not>
-               <property alias="/params/wing_left_broken/property"/>
-           </not>
+           <less-than>
+               <property alias="/params/wing_left_damaged/property"/>
+               <value>1.0</value>
+           </less-than>
 	       <not>
 			     <property alias="/params/crash/property"/>
 	       </not>
@@ -3168,9 +3160,10 @@
    <property>surface-positions/right-aileron-pos-norm</property>
    <condition>
 	   <and>
-           <not>
-               <property alias="/params/wing_right_broken/property"/>
-           </not>
+           <less-than>
+               <property alias="/params/wing_right_damaged/property"/>
+               <value>1.0</value>
+           </less-than>
 	       <not>
 			     <property alias="/params/crash/property"/>
 	       </not>
@@ -3546,11 +3539,14 @@
    <object-name>flapsD</object-name>
    <condition>
       <or>
-		  <property alias="/params/wing_left_damaged/property"/>
-		  <property alias="/params/wing_right_damaged/property"/>
-          <property alias="/params/wing_left_broken/property"/>
-          <property alias="/params/wing_right_broken/property"/>
-	      <property alias="/params/wing_both_broken/property"/>
+          <greater-than>
+		      <property alias="/params/wing_left_damaged/property"/>
+              <value>0.0</value>
+          </greater-than>
+          <greater-than>
+		      <property alias="/params/wing_right_damaged/property"/>
+              <value>0.0</value>
+          </greater-than>
           <property alias="/params/crash/property"/>
       </or>
    </condition>
@@ -3572,21 +3568,14 @@
    <object-name>landinglight2</object-name>
    <condition>
     <and>
-		<not>
+		<equals>
 		  <property alias="/params/wing_left_damaged/property"/>
-		</not>
-		<not>
+          <value>0.0</value>
+		</equals>
+		<equals>
 		  <property alias="/params/wing_right_damaged/property"/>
-		</not>
-        <not>
-            <property alias="/params/wing_left_broken/property"/>
-        </not>
-        <not>
-            <property alias="/params/wing_right_broken/property"/>
-        </not>
-		<not>
-			<property alias="/params/wing_both_broken/property"/>
-		</not>
+          <value>0.0</value>
+		</equals>
         <not>
             <property alias="/params/crash/property"/>
         </not>
@@ -3618,13 +3607,16 @@
    <object-name>wing_1BB</object-name>
    <condition>
       <and>
-	    <or>
-	        <property alias="/params/wing_both_broken/property"/>
-			<and>
-			    <property alias="/params/wing_left_broken/property"/>
-		        <property alias="/params/wing_right_broken/property"/>
-			</and>
-		</or>
+		<and>
+            <equals>
+		        <property alias="/params/wing_left_damaged/property"/>
+                <value>1.0</value>
+            </equals>
+            <equals>
+	            <property alias="/params/wing_right_damaged/property"/>
+                <value>1.0</value>
+            </equals>
+		</and>
 		<not>
 		    <property alias="/params/crash/property"/>
 		</not>
@@ -3647,19 +3639,24 @@
    <object-name>landinglight2BD</object-name>
    <condition>
 		<and>
-			<property alias="/params/wing_left_damaged/property"/>
-			<property alias="/params/wing_right_damaged/property"/>
-			<not>
-		      <property alias="/params/wing_left_broken/property"/>
-		    </not>
-		    <not>
-		      <property alias="/params/wing_right_broken/property"/>
-		    </not>
+            <greater-than>
+			    <property alias="/params/wing_left_damaged/property"/>
+                <value>0.0</value>
+            </greater-than>
+            <less-than>
+			    <property alias="/params/wing_left_damaged/property"/>
+                <value>1.0</value>
+            </less-than>
+            <greater-than>
+			    <property alias="/params/wing_right_damaged/property"/>
+                <value>0.0</value>
+            </greater-than>
+            <less-than>
+			    <property alias="/params/wing_right_damaged/property"/>
+                <value>1.0</value>
+            </less-than>
 			<not>
 			  <property alias="/params/crash/property"/>
-			</not>
-			<not>
-			  <property alias="/params/wing_both_broken/property"/>
 			</not>
 		</and>
    </condition>
@@ -3680,19 +3677,18 @@
    <object-name>landinglight2LD</object-name>
    <condition>
 	<and>
-		<property alias="/params/wing_left_damaged/property"/>
-		<not>
-		  <property alias="/params/wing_right_damaged/property"/>
-		</not>
-		<not>
-		  <property alias="/params/wing_left_broken/property"/>
-		</not>
-		<not>
-		  <property alias="/params/wing_right_broken/property"/>
-		</not>
-		<not>
-		  <property alias="/params/wing_both_broken/property"/>
-		</not>
+        <greater-than>
+		    <property alias="/params/wing_left_damaged/property"/>
+            <value>0.0</value>
+        </greater-than>
+        <less-than>
+		    <property alias="/params/wing_left_damaged/property"/>
+            <value>1.0</value>
+        </less-than>
+		<equals>
+		    <property alias="/params/wing_right_damaged/property"/>
+            <value>0.0</value>
+		</equals>
 		<not>
 		  <property alias="/params/crash/property"/>
 		</not>
@@ -3715,19 +3711,18 @@
    <object-name>landinglight2RD</object-name>
    <condition>
 	<and>
-		<property alias="/params/wing_right_damaged/property"/>
-		<not>
-		 <property alias="/params/wing_left_damaged/property"/>
-		</not>
-		<not>
-		  <property alias="/params/wing_left_broken/property"/>
-		</not>
-		<not>
-		  <property alias="/params/wing_right_broken/property"/>
-		</not>
-		<not>
-		  <property alias="/params/wing_both_broken/property"/>
-		</not>
+        <greater-than>
+		    <property alias="/params/wing_right_damaged/property"/>
+            <value>0.0</value>
+        </greater-than>
+        <less-than>
+		    <property alias="/params/wing_right_damaged/property"/>
+            <value>1.0</value>
+        </less-than>
+		<equals>
+		    <property alias="/params/wing_left_damaged/property"/>
+            <value>0.0</value>
+		</equals>
 		<not>
 		  <property alias="/params/crash/property"/>
 		</not>
@@ -3744,14 +3739,18 @@
    <object-name>navlight_rightDLB</object-name>
    <condition>
 	<and>
-		<property alias="/params/wing_left_broken/property"/>
-		<property alias="/params/wing_right_damaged/property"/>
-		<not>
-		  <property alias="/params/wing_right_broken/property"/>
-		</not>
-		<not>
-		  <property alias="/params/wing_both_broken/property"/>
-		</not>
+        <equals>
+		    <property alias="/params/wing_left_damaged/property"/>
+            <value>1.0</value>
+        </equals>
+        <greater-than>
+		    <property alias="/params/wing_right_damaged/property"/>
+            <value>0.0</value>
+        </greater-than>
+        <less-than>
+		    <property alias="/params/wing_right_damaged/property"/>
+            <value>1.0</value>
+        </less-than>
 		<not>
 		  <property alias="/params/crash/property"/>
 		</not>
@@ -3771,14 +3770,18 @@
    <object-name>landinglight2LDRB</object-name>
    <condition>
 	  <and>
-		<property alias="/params/wing_right_broken/property"/>
-		<property alias="/params/wing_left_damaged/property"/>
-		<not>
-		  <property alias="/params/wing_left_broken/property"/>
-		</not>
-		<not>
-		  <property alias="/params/wing_both_broken/property"/>
-		</not>
+        <equals>
+		    <property alias="/params/wing_right_damaged/property"/>
+            <value>1.0</value>
+        </equals>
+        <greater-than>
+		    <property alias="/params/wing_left_damaged/property"/>
+            <value>0.0</value>
+        </greater-than>
+        <less-than>
+		    <property alias="/params/wing_left_damaged/property"/>
+            <value>1.0</value>
+        </less-than>
 		<not>
 		  <property alias="/params/crash/property"/>
 		</not>
@@ -3795,16 +3798,14 @@
    <object-name>navlight_rightGLB</object-name>
    <condition>
 	<and>
-		<property alias="/params/wing_left_broken/property"/>
-		<not>
-		  <property alias="/params/wing_right_broken/property"/>
-		</not>
-		<not>
+		<equals>
+		    <property alias="/params/wing_left_damaged/property"/>
+            <value>1.0</value>
+		</equals>
+		<equals>
 		  <property alias="/params/wing_right_damaged/property"/>
-		</not>
-		<not>
-		  <property alias="/params/wing_both_broken/property"/>
-		</not>
+          <value>0.0</value>
+		</equals>
 		<not>
 		  <property alias="/params/crash/property"/>
 		</not>
@@ -3824,16 +3825,14 @@
    <object-name>landinglight2LGRB</object-name>
    <condition>
 	<and>
-		<property alias="/params/wing_right_broken/property"/>
-		<not>
-		  <property alias="/params/wing_left_broken/property"/>
-		</not>
-		<not>
-		  <property alias="/params/wing_left_damaged/property"/>
-		</not>
-		<not>
-		  <property alias="/params/wing_both_broken/property"/>
-		</not>
+		<equals>
+		    <property alias="/params/wing_right_damaged/property"/>
+            <value>1.0</value>
+		</equals>
+		<equals>
+		    <property alias="/params/wing_left_damaged/property"/>
+            <value>0.0</value>
+		</equals>
 		<not>
 		  <property alias="/params/crash/property"/>
 		</not>
@@ -4673,12 +4672,10 @@
        <not>
          <property>/sim/rendering/rembrandt/enabled</property>
        </not>
-	   <not>
-		  <property alias="/params/wing_left_broken/property"/>
-		</not>
-		<not>
-		  <property alias="/params/wing_both_broken/property"/>
-		</not>
+	   <less-than>
+		  <property alias="/params/wing_left_damaged/property"/>
+          <value>1.0</value>
+	   </less-than>
       </and>
    </condition>
  </animation>
@@ -4834,18 +4831,13 @@
    <condition>
        <and>
            <property alias="/params/lighting/strobes/property"/>
-		   <not>
+	       <equals>
 	           <property alias="/params/wing_left_damaged/property"/>
-	       </not>
-	       <not>
-	           <property alias="/params/wing_left_broken/property"/>
-	       </not>
+               <value>0.0</value>
+	       </equals>
 		   <not>
 	           <property alias="/params/crash/property"/>
 	       </not>
-		   <not>
-			 <property alias="/params/wing_both_broken/property"/>
-		   </not>
 	   </and>	
    </condition>
  </animation>
@@ -4856,18 +4848,13 @@
    <condition>
        <and>
            <property alias="/params/lighting/strobes/property"/>
-		   <not>
+	       <equals>
 	           <property alias="/params/wing_right_damaged/property"/>
-	       </not>
-	       <not>
-	           <property alias="/params/wing_right_broken/property"/>
-	       </not>
+               <value>0.0</value>
+	       </equals>
 		   <not>
 	           <property alias="/params/crash/property"/>
 	       </not>
-		   <not>
-			 <property alias="/params/wing_both_broken/property"/>
-		   </not>
 	   </and>	
    </condition>
  </animation>
@@ -4878,16 +4865,13 @@
    <condition>
        <and>
            <property alias="/params/lighting/strobes/property"/>
-		   <property alias="/params/wing_left_damaged/property"/>
-		   <not>
-	           <property alias="/params/wing_left_broken/property"/>
-		   </not>
+           <less-than>
+		       <property alias="/params/wing_left_damaged/property"/>
+               <value>1.0</value>
+           </less-than>
 		   <not>
 	           <property alias="/params/crash/property"/>
 	       </not>
-		   <not>
-			 <property alias="/params/wing_both_broken/property"/>
-		   </not>
 	   </and>
    </condition>
  </animation>
@@ -4898,16 +4882,13 @@
    <condition>
        <and>
            <property alias="/params/lighting/strobes/property"/>
-	       <property alias="/params/wing_right_damaged/property"/>
-		   <not>
-		       <property alias="/params/wing_right_broken/property"/>
-		   </not>
+           <less-than>
+	           <property alias="/params/wing_right_damaged/property"/>
+               <value>1.0</value>
+           </less-than>
 		   <not>
 	           <property alias="/params/crash/property"/>
 	       </not>
-		   <not>
-			 <property alias="/params/wing_both_broken/property"/>
-		   </not>
 	   </and>
    </condition>
  </animation>
@@ -5455,10 +5436,9 @@
           <property>sim/current-view/name</property>
           <value>Walker Orbit View</value>
         </not-equals>
-		<not-equals>
+		<not>
           <property>sim/model/occupants</property>
-          <value>false</value>
-        </not-equals>
+        </not>
       </and>
     </condition>
   </animation>
@@ -5472,10 +5452,7 @@
 				<property>payload/weight[1]/weight-lb</property>
 				<value>100</value>
 			</greater-than>
-			<equals>
-			  <property>sim/model/occupants</property>
-			  <value>true</value>
-			</equals>
+			<property>sim/model/occupants</property>
 		</and>
     </condition>
   </animation>
@@ -5488,10 +5465,7 @@
 				<property>payload/weight[2]/weight-lb</property>
 				<value>100</value>
 			</greater-than>
-			<equals>
-				<property>sim/model/occupants</property>
-				<value>true</value>
-			</equals>
+			<property>sim/model/occupants</property>
 		</and>
     </condition>
   </animation>
@@ -5504,10 +5478,7 @@
 				<property>payload/weight[3]/weight-lb</property>
 				<value>100</value>
 			</greater-than>
-			<equals>
-				<property>sim/model/occupants</property>
-				<value>true</value>
-			</equals>
+			<property>sim/model/occupants</property>
 		</and>
     </condition>
   </animation>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -84,10 +84,10 @@
                 <property>sim/multiplay/generic/int[2]</property>
             </strobes>
             <taxi>
-                <property>sim/multiplay/generic/float[4]</property>
+                <property>sim/multiplay/generic/int[4]</property>
             </taxi>
             <landing>
-                <property>sim/multiplay/generic/float[5]</property>
+                <property>sim/multiplay/generic/int[5]</property>
             </landing>
         </lighting>
         <doors>
@@ -4672,10 +4672,6 @@
        <not>
          <property>/sim/rendering/rembrandt/enabled</property>
        </not>
-	   <less-than>
-		  <property alias="/params/wing_left_damaged/property"/>
-          <value>1.0</value>
-	   </less-than>
       </and>
    </condition>
  </animation>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -4037,7 +4037,10 @@
    <object-name>L-FloatCB</object-name>
    <condition>
       <and>
-	    <property alias="/params/pontoon_left_broken/property"/>
+        <equals>
+	        <property alias="/params/pontoon_left_damaged/property"/>
+            <value>1</value>
+        </equals>
 		<equals>
 		  <property alias="/params/bushkit/property"/>
 		  <value>3</value>
@@ -4052,7 +4055,10 @@
    <object-name>R-FloatCB</object-name>
    <condition>
 	  <and>
-	    <property alias="/params/pontoon_right_broken/property"/>
+        <equals>
+	      <property alias="/params/pontoon_right_damaged/property"/>
+		  <value>1</value>
+        </equals>
 		<equals>
 		  <property alias="/params/bushkit/property"/>
 		  <value>3</value>
@@ -4115,7 +4121,10 @@
    <object-name>LstrutOB.002</object-name>
    <condition>
       <and>
-	    <property alias="/params/pontoon_left_broken/property"/>
+        <equals>
+	        <property alias="/params/pontoon_left_damaged/property"/>
+            <value>1</value>
+        </equals>
 		<equals>
 		  <property alias="/params/bushkit/property"/>
 		  <value>4</value>
@@ -4134,7 +4143,10 @@
    <object-name>RstrutOB.002</object-name>
    <condition>
 	  <and>
-	    <property alias="/params/pontoon_right_broken/property"/>
+        <equals>
+	        <property alias="/params/pontoon_right_damaged/property"/>
+		    <value>1</value>
+        </equals>
 		<equals>
 		  <property alias="/params/bushkit/property"/>
 		  <value>4</value>
@@ -4197,7 +4209,10 @@
    <object-name>LHrudderB</object-name>
    <condition>
       <and>
-	    <property alias="/params/pontoon_left_broken/property"/>
+        <equals>
+	        <property alias="/params/pontoon_left_damaged/property"/>
+            <value>1</value>
+        </equals>
 		<or>
 			<equals>
 			  <property alias="/params/bushkit/property"/>
@@ -4218,7 +4233,10 @@
    <object-name>RHrudderB</object-name>
    <condition>
 	  <and>
-	    <property alias="/params/pontoon_right_broken/property"/>
+        <equals>
+	        <property alias="/params/pontoon_right_damaged/property"/>
+            <value>1</value>
+        </equals>
 		<or>
 			<equals>
 			  <property alias="/params/bushkit/property"/>

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -128,10 +128,8 @@ var reset_system = func {
     props.globals.getNode("/fdm/jsbsim/gear/unit[0]/broken", 0).setBoolValue(0);
     props.globals.getNode("/fdm/jsbsim/gear/unit[1]/broken", 0).setBoolValue(0);
     props.globals.getNode("/fdm/jsbsim/gear/unit[2]/broken", 0).setBoolValue(0);
-	props.globals.getNode("/fdm/jsbsim/left-pontoon/damaged", 0).setBoolValue(0);
-    props.globals.getNode("/fdm/jsbsim/left-pontoon/broken", 0).setBoolValue(0);
-	props.globals.getNode("/fdm/jsbsim/right-pontoon/damaged", 0).setBoolValue(0);
-    props.globals.getNode("/fdm/jsbsim/right-pontoon/broken", 0).setBoolValue(0);
+	props.globals.getNode("/fdm/jsbsim/pontoon-damage/left-pontoon", 0).setIntValue(0);
+	props.globals.getNode("/fdm/jsbsim/pontoon-damage/right-pontoon", 0).setIntValue(0);
 
 	setprop("/engines/active-engine/killed", 0);
 	setprop("/fdm/jsbsim/contact/unit[4]/z-position", 50);

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -125,13 +125,9 @@ var reset_system = func {
     # appear to receive the random values from the MP properties during initialization.
     # Therefore, override these random values with the proper values we want.
     props.globals.getNode("/fdm/jsbsim/crash", 0).setBoolValue(0);
-    props.globals.getNode("/fdm/jsbsim/contact/unit[4]/broken", 0).setBoolValue(0);
-    props.globals.getNode("/fdm/jsbsim/contact/unit[5]/broken", 0).setBoolValue(0);
     props.globals.getNode("/fdm/jsbsim/gear/unit[0]/broken", 0).setBoolValue(0);
     props.globals.getNode("/fdm/jsbsim/gear/unit[1]/broken", 0).setBoolValue(0);
     props.globals.getNode("/fdm/jsbsim/gear/unit[2]/broken", 0).setBoolValue(0);
-    props.globals.getNode("/fdm/jsbsim/wing-damage/left-wing", 0).setBoolValue(0);
-    props.globals.getNode("/fdm/jsbsim/wing-damage/right-wing", 0).setBoolValue(0);
 	props.globals.getNode("/fdm/jsbsim/left-pontoon/damaged", 0).setBoolValue(0);
     props.globals.getNode("/fdm/jsbsim/left-pontoon/broken", 0).setBoolValue(0);
 	props.globals.getNode("/fdm/jsbsim/right-pontoon/damaged", 0).setBoolValue(0);

--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -147,21 +147,17 @@ var bothwingsbroke = func
     rightwingbroke();
 }
 
-var upsidedown = func (left_wing_damage, right_wing_damage)
+var upsidedown = func
 {
 	setprop(contact~"unit[12]/z-position", 90);
 
 	if (getprop(contact~"unit[4]/broken"))
 		setprop(contact~"unit[4]/z-position", 40);
-	elsif (left_wing_damage > 1)
-		setprop(contact~"unit[4]/z-position", 85);
 	else
 		setprop(contact~"unit[4]/z-position", 50);
 
 	if (getprop(contact~"unit[5]/broken"))
 		setprop(contact~"unit[5]/z-position", 40);
-	elsif (right_wing_damage > 1)
-		setprop(contact~"unit[5]/z-position", 85);
 	else
 		setprop(contact~"unit[5]/z-position", 50);
 }
@@ -301,15 +297,15 @@ var poll_damage = func
     var left_wing_damage = getprop("/fdm/jsbsim/wing-damage/left-wing");
     var right_wing_damage = getprop("/fdm/jsbsim/wing-damage/right-wing");
 
-	if (gears_broken == 3 and left_wing_damage < 1 and right_wing_damage < 1)
+	if (gears_broken == 3 and left_wing_damage != 1 and right_wing_damage != 1)
 		bothwingcollapse();
 
     var crash = getprop("/fdm/jsbsim/crash");
 
 	if (getprop(contact~"unit[12]/WOW"))
-		upsidedown(left_wing_damage, right_wing_damage);
+		upsidedown();
 
-	if (getprop("position/altitude-agl-m") < 10 and (crash or left_wing_damage > 0.5 or right_wing_damage > 0.5))
+	if (getprop("position/altitude-agl-m") < 10 and (crash or left_wing_damage == 1 or right_wing_damage == 1))
 		killengine();
 
     # IN-FLIGHT DAMAGES
@@ -327,7 +323,7 @@ var poll_damage = func
 
     if (airspeed > limit_vne * 1.225) # Vne x sqrt(1.5) ~ 200 KIAS
 	{
-		if (!crash and left_wing_damage < 1 and right_wing_damage < 1)
+		if (!crash and left_wing_damage != 1 and right_wing_damage != 1)
 		{
 			bothwingsbroke();
 			gui.popupTip("Overspeed!! Both wings BROKEN", 5);
@@ -336,21 +332,21 @@ var poll_damage = func
 	elsif (airspeed > limit_vne * 1.14) # 180 KIAS
 	{
         if (roll_moment < -4000) {
-		    if (left_wing_damage < 0.5) {
+		    if (left_wing_damage == 0 or left_wing_damage == 2) {
 			    rightwingbroke();
                 gui.popupTip("Overspeed!! Right wing BROKEN", 5);
             }
 		}
 		elsif (roll_moment > 4000) {
-		    if (right_wing_damage < 0.5) {
+		    if (right_wing_damage == 0 or right_wing_damage == 2) {
 			    leftwingbroke();
                 gui.popupTip("Overspeed!! Left wing BROKEN", 5);
             }
 		}
 		else {
 		    if (left_wing_damage == 0 and right_wing_damage == 0) {
-			    setprop("/fdm/jsbsim/wing-damage/left-wing", 0.3);
-                setprop("/fdm/jsbsim/wing-damage/right-wing", 0.3);
+			    setprop("/fdm/jsbsim/wing-damage/left-wing", 3);
+                setprop("/fdm/jsbsim/wing-damage/right-wing", 3);
                 gui.popupTip("Overspeed. Both wing DAMAGED", 5);
 		    }
 		}
@@ -359,13 +355,13 @@ var poll_damage = func
 	{
 		if (roll_moment < -4000 and left_wing_damage == 0)
 		{
-			setprop("/fdm/jsbsim/wing-damage/right-wing", 0.12);
+			setprop("/fdm/jsbsim/wing-damage/right-wing", 2);
             gui.popupTip("Overspeed. Right wing DAMAGED!!", 5);
 		}
 		
 		if (roll_moment > 4000 and right_wing_damage == 0)
 		{
-			setprop("/fdm/jsbsim/wing-damage/left-wing", 0.12);
+			setprop("/fdm/jsbsim/wing-damage/left-wing", 2);
             gui.popupTip("Overspeed. Left wing DAMAGED!!", 5);
 		}
 	}        
@@ -384,12 +380,12 @@ var poll_damage = func
 	}
 	elsif (lift_force > max_lift_force * 1.25)
 	{
-		if (roll_moment < -4000 and left_wing_damage < 1)
+		if (roll_moment < -4000 and left_wing_damage != 1)
 		{
 			rightwingbroke();
             gui.popupTip("Over-load Right wing BROKEN", 5);
 		}
-		if (roll_moment > 4000 and right_wing_damage < 1)
+		if (roll_moment > 4000 and right_wing_damage != 1)
 		{
 			leftwingbroke();
             gui.popupTip("Over-load Left wing BROKEN", 5);
@@ -400,12 +396,12 @@ var poll_damage = func
 #        print("Lift-Force: ", lift_force);
 		if (roll_moment < -4000 and left_wing_damage == 0)
 		{
-			setprop("/fdm/jsbsim/wing-damage/right-wing", 0.12);
+			setprop("/fdm/jsbsim/wing-damage/right-wing", 2);
             gui.popupTip("Over-load Right wing DAMAGED!!", 5);
 		}
 		if (roll_moment > 4000 and right_wing_damage == 0)
 		{
-			setprop("/fdm/jsbsim/wing-damage/left-wing", 0.12);
+			setprop("/fdm/jsbsim/wing-damage/left-wing", 2);
             gui.popupTip("Over-load Left wing DAMAGED!!", 5);
 		}
 	}

--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -1,22 +1,3 @@
-props.Node.new({ "/fdm/jsbsim/bushkit":0 });
-props.globals.initNode("/fdm/jsbsim/bushkit", 0, "INT");
-
-# Specifications Vne=158 KIAS,
-# Normal category (1500 - 2400 or 2550 lbs): max positive-g=3.8, max negative-g=1.52,
-# Utility category (1500 - 2100 lbs): max positive-g=4.4, max negative-g=1.76,
-# structure holds at least 150% max g's
-props.Node.new({ "limits/vne":0 });
-props.globals.initNode("limits/vne", 158, "DOUBLE");
-props.Node.new({ "limits/max-positive-g":0 });
-props.globals.initNode("limits/max-positive-g", 3.8, "DOUBLE");
-props.Node.new({ "limits/max-negative-g":0 });
-props.globals.initNode("limits/max-negative-g", -1.52, "DOUBLE");
-props.Node.new({ "limits/max-lift-force":0 });
-props.globals.initNode("limits/max-lift-force", 2550*3.8, "DOUBLE");
-
-var g = getprop("/fdm/jsbsim/accelerations/Nz");
-var max_positive = getprop("limits/max-positive-g");
-var max_negative = getprop("limits/max-negative-g");
 var max_lift_force = getprop("limits/max-lift-force");
 var lift_force = -getprop("/fdm/jsbsim/forces/fbz-aero-lbs");
 
@@ -32,36 +13,19 @@ var get_gear_force = func (index, spring_coeff, damping_coeff) {
     return spring_coeff * compr + damping_coeff * compr_vel;
 };
 
-var force0 = get_gear_force(0, 1800, 600); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for NOSE
-var force1 = get_gear_force(1, 5400, 400); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for LEFT gear
-var force2 = get_gear_force(2, 5400, 400); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for RIGHT gear
+# MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for nose and main gear
+var force0 = get_gear_force(0, 1800, 600);
+var force1 = get_gear_force(1, 5400, 400);
+var force2 = get_gear_force(2, 5400, 400);
 
 var gear_side_force = getprop("/fdm/jsbsim/forces/fby-gear-lbs");
 
 var gears = "fdm/jsbsim/gear/";
 var contact = "fdm/jsbsim/contact/";
-var lastkit=0;
-var settledelay=0;
 
 var fairing1 = 0;
 var fairing2 = 0;
 var fairing3 = 0;
-
-#Uncomment for resetting damage
-#props.Node.new({ "/sim/rendering/nosedamage":0 });
-#props.globals.initNode("/sim/rendering/nosedamage", 0, "INT");
-#props.Node.new({ "/sim/rendering/leftgeardamage":0 });
-#props.globals.initNode("/sim/rendering/leftgeardamage", 0, "INT");
-#props.Node.new({ "/sim/rendering/rightgeardamage":0 });
-#props.globals.initNode("/sim/rendering/rightgeardamage", 0, "INT");
-#props.Node.new({ "/sim/rendering/alldamage":0 });
-#props.globals.initNode("/sim/rendering/alldamage", 0, "INT");
-#props.Node.new({ "/sim/rendering/rightwingdamage":0 });
-#props.globals.initNode("/sim/rendering/rightwingdamage", 0, "INT");
-#props.Node.new({ "/sim/rendering/leftwingdamage":0 });
-#props.globals.initNode("/sim/rendering/leftwingdamage", 0, "INT");
-#props.Node.new({ "/sim/rendering/allfix":0 });
-#props.globals.initNode("/sim/rendering/allfix", 0, "INT");
 
 var resetalldamage = func
 {
@@ -86,15 +50,6 @@ var resetalldamage = func
 	setprop("/fdm/jsbsim/left-pontoon/broken", 0);
 	setprop("/fdm/jsbsim/right-pontoon/damaged", 0);
 	setprop("/fdm/jsbsim/right-pontoon/broken", 0);
-	#setprop("/sim/rendering/nosedamage", 0);
-	#setprop("/sim/rendering/leftgeardamage", 0);
-	#setprop("/sim/rendering/rightgeardamage", 0);
-	#setprop("/sim/rendering/leftwingdamage", 0);
-	#setprop("/sim/rendering/rightwingdamage", 0);
-	#setprop("/sim/rendering/bothwingdamage", 0);
-	#setprop("/sim/rendering/alldamage", 0);
-	#setprop("/sim/rendering/allfix", 0);
-	lastkit=5;
 }
 
 var nosegearbroke = func

--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -330,7 +330,7 @@ var poll_damage = func
     # Over-g damages, over-forces on wings
     var lift_force = -getprop("/fdm/jsbsim/forces/fbz-aero-lbs");
 
-    if (lift_force > max_lift_force * 1.5)
+    if (lift_force > max_lift_force * 1.75)
 	{
 		if (!crash)
 		{
@@ -338,7 +338,7 @@ var poll_damage = func
 			gui.popupTip("Over-load Both wings BROKEN!", 5);
 		}
 	}
-	elsif (lift_force > max_lift_force * 1.25)
+	elsif (lift_force > max_lift_force * 1.4)
 	{
 		if (roll_moment < -4000 and left_wing_damage < 1)
 		{
@@ -350,6 +350,20 @@ var poll_damage = func
 			leftwingbroke();
             gui.popupTip("Over-load Left wing BROKEN!", 5);
 		}
+        else
+        {
+            if (left_wing_damage == 0)
+                setprop("/fdm/jsbsim/wing-damage/right-wing", 0.12);
+            else
+                setprop("/fdm/jsbsim/wing-damage/right-wing", 0.3);
+
+            if (right_wing_damage == 0)
+                setprop("/fdm/jsbsim/wing-damage/left-wing", 0.12);
+            else
+                setprop("/fdm/jsbsim/wing-damage/left-wing", 0.3);
+            if (left_wing_damage == 0 and right_wing_damage == 0)
+			    gui.popupTip("Over-load Both wings DAMAGED!", 5);
+        }
 	}
     elsif (lift_force > max_lift_force)
 	{

--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -1,16 +1,6 @@
 var max_lift_force = getprop("limits/max-lift-force");
 var limit_vne = getprop("limits/vne");
 
-var aero_coeff = "fdm/jsbsim/aero/coefficient/";
-
-var get_gear_force = func (index, spring_coeff, damping_coeff) {
-    # Force-on-gear = (compression-ft) x (spring_coeff) + (compression-velocity-fps) x (damping_coeff)
-
-    var compr = getprop("/fdm/jsbsim/gear/unit", index, "compression-ft");
-    var compr_vel = getprop("/fdm/jsbsim/gear/unit", index, "compression-velocity-fps");
-    return spring_coeff * compr + damping_coeff * compr_vel;
-};
-
 var gears = "fdm/jsbsim/gear/";
 var contact = "fdm/jsbsim/contact/";
 
@@ -97,37 +87,33 @@ var rightgearbroke = func (bushkit)
 	setprop(gears~"unit[2]/z-position", 0);
 }
 
-var leftpontoondamaged = func (bushkit)
+var leftpontoondamaged = func
 {
-	if ((bushkit == 3 or bushkit == 4) and !getprop("/fdm/jsbsim/left-pontoon/broken"))
+	if (!getprop("/fdm/jsbsim/left-pontoon/broken"))
 		setprop("/fdm/jsbsim/left-pontoon/damaged", 1);
 
     killengine();
 }
 
-var leftpontoonbroke = func (bushkit)
+var leftpontoonbroke = func
 {
-	if (bushkit == 3 or bushkit == 4) {
-		setprop("/fdm/jsbsim/left-pontoon/damaged", 0);
-		setprop("/fdm/jsbsim/left-pontoon/broken", 1);
-	}
+	setprop("/fdm/jsbsim/left-pontoon/damaged", 0);
+	setprop("/fdm/jsbsim/left-pontoon/broken", 1);
     killengine();
 }
 
-var rightpontoondamaged = func (bushkit)
+var rightpontoondamaged = func
 {
-	if ((bushkit == 3 or bushkit == 4) and !getprop("/fdm/jsbsim/right-pontoon/broken"))
+	if (!getprop("/fdm/jsbsim/right-pontoon/broken"))
 		setprop("/fdm/jsbsim/right-pontoon/damaged", 1);
 
     killengine();
 }
 
-var rightpontoonbroke = func (bushkit)
+var rightpontoonbroke = func
 {
-	if (bushkit == 3 or bushkit == 4) {
-		setprop("/fdm/jsbsim/right-pontoon/damaged", 0);
-		setprop("/fdm/jsbsim/right-pontoon/broken", 1);
-	}
+	setprop("/fdm/jsbsim/right-pontoon/damaged", 0);
+	setprop("/fdm/jsbsim/right-pontoon/broken", 1);
     killengine();
 }
 
@@ -216,37 +202,39 @@ var poll_damage = func
     var bushkit = getprop("/fdm/jsbsim/bushkit");
     var gears_broken = 0;
 
-    var unit_13_comp = getprop(contact~"unit[13]/compression-ft");
-    var unit_15_comp = getprop(contact~"unit[15]/compression-ft");
-    var unit_17_comp = getprop(contact~"unit[17]/compression-ft");
-    var unit_19_comp = getprop(gears~"unit[19]/compression-ft");
-    var unit_21_comp = getprop(gears~"unit[21]/compression-ft");
+    if (bushkit == 3 or bushkit == 4) {
+        var unit_13_comp = getprop(contact~"unit[13]/compression-ft");
+        var unit_15_comp = getprop(contact~"unit[15]/compression-ft");
+        var unit_17_comp = getprop(contact~"unit[17]/compression-ft");
+        var unit_19_comp = getprop(gears~"unit[19]/compression-ft");
+        var unit_21_comp = getprop(gears~"unit[21]/compression-ft");
 
-    var max_left_pontoon_gear_comp = std.max(unit_19_comp, unit_21_comp);
+        var max_left_pontoon_gear_comp = std.max(unit_19_comp, unit_21_comp);
 
-    # Left pontoon
-    if (unit_13_comp > 0.95 or unit_15_comp > 0.95 or unit_17_comp > 0.95 or
-		max_left_pontoon_gear_comp > 0.95)
-		leftpontoonbroke(bushkit);
-	elsif (unit_13_comp > 0.75 or unit_15_comp > 0.75 or unit_17_comp > 0.75 or
-		max_left_pontoon_gear_comp > 0.75)
-		leftpontoondamaged(bushkit);
+        # Left pontoon
+        if (unit_13_comp > 0.95 or unit_15_comp > 0.95 or unit_17_comp > 0.95 or
+		    max_left_pontoon_gear_comp > 0.95)
+		    leftpontoonbroke();
+	    elsif (unit_13_comp > 0.75 or unit_15_comp > 0.75 or unit_17_comp > 0.75 or
+		    max_left_pontoon_gear_comp > 0.75)
+		    leftpontoondamaged();
 
-    var unit_14_comp = getprop(contact~"unit[14]/compression-ft");
-    var unit_16_comp = getprop(contact~"unit[16]/compression-ft");
-    var unit_18_comp = getprop(contact~"unit[18]/compression-ft");
-    var unit_20_comp = getprop(gears~"unit[20]/compression-ft");
-    var unit_22_comp = getprop(gears~"unit[22]/compression-ft");
+        var unit_14_comp = getprop(contact~"unit[14]/compression-ft");
+        var unit_16_comp = getprop(contact~"unit[16]/compression-ft");
+        var unit_18_comp = getprop(contact~"unit[18]/compression-ft");
+        var unit_20_comp = getprop(gears~"unit[20]/compression-ft");
+        var unit_22_comp = getprop(gears~"unit[22]/compression-ft");
 
-    var max_right_pontoon_gear_comp = std.max(unit_20_comp, unit_22_comp);
+        var max_right_pontoon_gear_comp = std.max(unit_20_comp, unit_22_comp);
 
-    # Right pontoon
-    if (unit_14_comp > 0.95 or unit_16_comp > 0.95 or unit_18_comp > 0.95 or
-		max_right_pontoon_gear_comp > 0.95)
-		rightpontoonbroke(bushkit);
-	elsif (unit_14_comp > 0.75 or unit_16_comp > 0.75 or unit_18_comp > 0.75 or
-		max_right_pontoon_gear_comp > 0.75)
-		rightpontoondamaged(bushkit);
+        # Right pontoon
+        if (unit_14_comp > 0.95 or unit_16_comp > 0.95 or unit_18_comp > 0.95 or
+		    max_right_pontoon_gear_comp > 0.95)
+		    rightpontoonbroke();
+	    elsif (unit_14_comp > 0.75 or unit_16_comp > 0.75 or unit_18_comp > 0.75 or
+		    max_right_pontoon_gear_comp > 0.75)
+		    rightpontoondamaged();
+    }
 
 	if (getprop(contact~"unit[4]/compression-ft") > 0.005)
 		leftwingbroke();
@@ -270,14 +258,7 @@ var poll_damage = func
 		killengine();
 
     # IN-FLIGHT DAMAGES
-
-    # Roll moment due to (diedra + roll rate + yaw rate + ailerons)
-    # => asymmetry to break one wing
-    var roll_moment = getprop(aero_coeff~"Clb")
-        + getprop(aero_coeff~"Clp")
-        + getprop(aero_coeff~"Clr")
-        + getprop(aero_coeff~"ClDa");
-#    print("Roll-moment: ", roll_moment);
+    var roll_moment = getprop("/fdm/jsbsim/damage/roll-moment");
 
     # Over-speed damages
     var airspeed = getprop("velocities/airspeed-kt");

--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -74,14 +74,6 @@ var rightgearbroke = func (bushkit)
 	setprop(gears~"unit[2]/z-position", 0);
 }
 
-var leftpontoonbroke = func {
-    # FIXME Of which units do we need to update the z-position?
-};
-
-var rightpontoonbroke = func {
-    # FIXME Of which units do we need to update the z-position?
-};
-
 var bothwingcollapse = func
 {
 	setprop(contact~"unit[5]/z-position", -8);
@@ -308,8 +300,6 @@ setlistener("/sim/signals/fdm-initialized", func {
                 gui.popupTip("Both pontoons BROKEN!", 5);
             else
                 gui.popupTip("Left pontoon BROKEN!", 5);
-
-            leftpontoonbroke();
         }
         elsif (left_pontoon == 2) {
             if (right_pontoon == 2)
@@ -331,8 +321,6 @@ setlistener("/sim/signals/fdm-initialized", func {
                 gui.popupTip("Both pontoons BROKEN!", 5);
             else
                 gui.popupTip("Right pontoon BROKEN!", 5);
-
-            rightpontoonbroke();
         }
         elsif (right_pontoon == 2) {
             if (left_pontoon == 2)

--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -42,7 +42,6 @@ var resetalldamage = func
 	setprop(contact~"unit[12]/z-position", 90);
 	setprop("/fdm/jsbsim/wing-damage/left-wing", 0);
 	setprop("/fdm/jsbsim/wing-damage/right-wing", 0);
-	setprop("/fdm/jsbsim/wing-both/broken", 0);
 	setprop("/fdm/jsbsim/crash", 0);
 	setprop("/fdm/jsbsim/left-pontoon/damaged", 0);
 	setprop("/fdm/jsbsim/left-pontoon/broken", 0);
@@ -144,11 +143,8 @@ var bothwingcollapse = func
 
 var bothwingsbroke = func
 {
-	setprop(contact~"unit[4]/broken", 1);
-	setprop(contact~"unit[5]/broken", 1);
-	setprop("/fdm/jsbsim/wing-damage/left-wing", 1);
-	setprop("/fdm/jsbsim/wing-damage/right-wing", 1);
-	setprop("/fdm/jsbsim/wing-both/broken", 1);
+    leftwingbroke();
+    rightwingbroke();
 }
 
 var upsidedown = func (left_wing_damage, right_wing_damage)
@@ -304,10 +300,11 @@ var poll_damage = func
 
     var left_wing_damage = getprop("/fdm/jsbsim/wing-damage/left-wing");
     var right_wing_damage = getprop("/fdm/jsbsim/wing-damage/right-wing");
-    var crash = getprop("/fdm/jsbsim/crash");
 
-	if (gears_broken == 3 and !getprop("/fdm/jsbsim/wing-both/broken") and left_wing_damage < 1 and right_wing_damage < 1)
+	if (gears_broken == 3 and left_wing_damage < 1 and right_wing_damage < 1)
 		bothwingcollapse();
+
+    var crash = getprop("/fdm/jsbsim/crash");
 
 	if (getprop(contact~"unit[12]/WOW"))
 		upsidedown(left_wing_damage, right_wing_damage);

--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -1,9 +1,7 @@
 var max_lift_force = getprop("limits/max-lift-force");
-var lift_force = -getprop("/fdm/jsbsim/forces/fbz-aero-lbs");
+var limit_vne = getprop("limits/vne");
 
 var aero_coeff = "fdm/jsbsim/aero/coefficient/";
-#Roll moment due to (diedra + roll rate + yaw rate + ailerons) ==> asymmetry to break one wing
-var roll_moment = getprop(aero_coeff~"Clb")+getprop(aero_coeff~"Clp")+getprop(aero_coeff~"Clr")+getprop(aero_coeff~"ClDa");
 
 var get_gear_force = func (index, spring_coeff, damping_coeff) {
     # Force-on-gear = (compression-ft) x (spring_coeff) + (compression-velocity-fps) x (damping_coeff)
@@ -52,15 +50,13 @@ var resetalldamage = func
 	setprop("/fdm/jsbsim/right-pontoon/broken", 0);
 }
 
-var nosegearbroke = func
+var nosegearbroke = func (bushkit)
 {
-	if(getprop("/fdm/jsbsim/bushkit") == 0)
+	if (bushkit == 0)
 		setprop(contact~"unit[6]/z-position", -10);
-	else 
-    if(getprop("/fdm/jsbsim/bushkit") == 1)
+	elsif (bushkit == 1)
 		setprop(contact~"unit[6]/z-position", -18.5);
-	else
-	if(getprop("/fdm/jsbsim/bushkit") == 2)
+	elsif (bushkit == 2)
 		setprop(contact~"unit[6]/z-position", -17.7);
 
 	setprop(gears~"unit[0]/z-position", 0);
@@ -68,68 +64,60 @@ var nosegearbroke = func
 	setprop(gears~"unit[0]/broken", 1);
 }
 
-var leftgearbroke = func
+var leftgearbroke = func (bushkit)
 {
-	if(getprop("/fdm/jsbsim/bushkit") == 0)
+	if (bushkit == 0)
 		setprop(contact~"unit[7]/z-position", -9.5);
-	else 
-    if(getprop("/fdm/jsbsim/bushkit") == 1)
+	elsif (bushkit == 1)
 		setprop(contact~"unit[7]/z-position", -14.5);
-	else
-	if(getprop("/fdm/jsbsim/bushkit") == 2)
+	elsif (bushkit == 2)
 		setprop(contact~"unit[7]/z-position", -16);
 
 	setprop(gears~"unit[1]/z-position", 0);
 	setprop(gears~"unit[1]/broken", 1);
 }
 
-var rightgearbroke = func
+var rightgearbroke = func (bushkit)
 {
-	if(getprop("/fdm/jsbsim/bushkit") == 0)
+	if (bushkit == 0)
 		setprop(contact~"unit[8]/z-position", -8);
-	else 
-    if(getprop("/fdm/jsbsim/bushkit") == 1)
+	elsif (bushkit == 1)
 		setprop(contact~"unit[8]/z-position", -15.5);
-	else
-	if(getprop("/fdm/jsbsim/bushkit") == 2)
+	elsif (bushkit == 2)
 		setprop(contact~"unit[8]/z-position", -17.4);
 
 	setprop(gears~"unit[2]/z-position", 0);
 	setprop(gears~"unit[2]/broken", 1);
 }
 
-var leftpontoondamaged = func
+var leftpontoondamaged = func (bushkit)
 {
-	if(getprop("/fdm/jsbsim/bushkit") == 3 or getprop("/fdm/jsbsim/bushkit") == 4)
-		if(!getprop("/fdm/jsbsim/left-pontoon/broken"))
-			setprop("/fdm/jsbsim/left-pontoon/damaged", 1);
+	if ((bushkit == 3 or bushkit == 4) and !getprop("/fdm/jsbsim/left-pontoon/broken"))
+		setprop("/fdm/jsbsim/left-pontoon/damaged", 1);
 
     killengine();
 }
 
-var leftpontoonbroke = func
+var leftpontoonbroke = func (bushkit)
 {
-	if(getprop("/fdm/jsbsim/bushkit") == 3 or getprop("/fdm/jsbsim/bushkit") == 4)
-	{
+	if (bushkit == 3 or bushkit == 4) {
 		setprop("/fdm/jsbsim/left-pontoon/damaged", 0);
 		setprop("/fdm/jsbsim/left-pontoon/broken", 1);
 	}
     killengine();
 }
 
-var rightpontoondamaged = func
+var rightpontoondamaged = func (bushkit)
 {
-	if(getprop("/fdm/jsbsim/bushkit") == 3 or getprop("/fdm/jsbsim/bushkit") == 4)
-		if(!getprop("/fdm/jsbsim/right-pontoon/broken"))
-			setprop("/fdm/jsbsim/right-pontoon/damaged", 1);
+	if ((bushkit == 3 or bushkit == 4) and !getprop("/fdm/jsbsim/right-pontoon/broken"))
+		setprop("/fdm/jsbsim/right-pontoon/damaged", 1);
 
     killengine();
 }
 
-var rightpontoonbroke = func
+var rightpontoonbroke = func (bushkit)
 {
-	if(getprop("/fdm/jsbsim/bushkit") == 3 or getprop("/fdm/jsbsim/bushkit") == 4)
-	{
+	if (bushkit == 3 or bushkit == 4) {
 		setprop("/fdm/jsbsim/right-pontoon/damaged", 0);
 		setprop("/fdm/jsbsim/right-pontoon/broken", 1);
 	}
@@ -163,21 +151,20 @@ var bothwingsbroke = func
 	setprop("/fdm/jsbsim/wing-both/broken", 1);
 }
 
-var upsidedown = func
+var upsidedown = func (left_wing_damage, right_wing_damage)
 {
 	setprop(contact~"unit[12]/z-position", 90);
+
 	if (getprop(contact~"unit[4]/broken"))
 		setprop(contact~"unit[4]/z-position", 40);
-	else
-	if(getprop("/fdm/jsbsim/wing-damage/left-wing") > 1)
+	elsif (left_wing_damage > 1)
 		setprop(contact~"unit[4]/z-position", 85);
 	else
 		setprop(contact~"unit[4]/z-position", 50);
 
 	if (getprop(contact~"unit[5]/broken"))
 		setprop(contact~"unit[5]/z-position", 40);
-	else
-	if(getprop("/fdm/jsbsim/wing-damage/right-wing") > 1)
+	elsif (right_wing_damage > 1)
 		setprop(contact~"unit[5]/z-position", 85);
 	else
 		setprop(contact~"unit[5]/z-position", 50);
@@ -204,8 +191,6 @@ var resetcontacts = func
 
 var defaulttires = func
 {
-	resetalldamage();
-	resetcontacts();
 	setprop(gears~"unit[0]/z-position", -19.5);
 	setprop(gears~"unit[1]/z-position", -15.5);
 	setprop(gears~"unit[2]/z-position", -15.5);
@@ -213,8 +198,6 @@ var defaulttires = func
 
 var medbushtires = func
 {
-	resetalldamage();
-	resetcontacts();
 	setprop(gears~"unit[0]/z-position", -22);
 	setprop(gears~"unit[1]/z-position", -20);
 	setprop(gears~"unit[2]/z-position", -20);
@@ -222,8 +205,6 @@ var medbushtires = func
 
 var largebushtires = func
 {
-	resetalldamage();
-	resetcontacts();
 	setprop(gears~"unit[0]/z-position", -22);
 	setprop(gears~"unit[1]/z-position", -22);
 	setprop(gears~"unit[2]/z-position", -22);
@@ -231,14 +212,11 @@ var largebushtires = func
 
 var pontoons = func
 {
-	resetalldamage();
-	resetcontacts();
+    # Empty, no z-position's to reset
 }
 
 var amphibious = func
 {
-	resetcontacts();
-	resetalldamage();
 	setprop(gears~"unit[19]/z-position", -62);
 	setprop(gears~"unit[20]/z-position", -62);
 	setprop(gears~"unit[21]/z-position", -50.5);
@@ -247,205 +225,220 @@ var amphibious = func
 
 var poll_damage = func
 {
+    # GROUND DAMAGES
 
-# GROUND DAMAGES
-
-    force0 = get_gear_force(0, 1800, 600); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for NOSE
-    force1 = get_gear_force(1, 5400, 400); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for LEFT gear
-    force2 = get_gear_force(2, 5400, 400); # MUST be the same coefficients as spring_coeff and damping_coeff in the FDM for RIGHT gear
+    # MUST be the same coefficients as spring_coeff and damping_coeff
+    # in the FDM for nose and main gear
+    force0 = get_gear_force(0, 1800, 600);
+    force1 = get_gear_force(1, 5400, 400);
+    force2 = get_gear_force(2, 5400, 400);
 
     gear_side_force = getprop("/fdm/jsbsim/forces/fby-gear-lbs");
-    
+
 #    # For tests: forces (LBS) exerted on gears (along Z and Y), uncomment these lines.
-#    if(force0 > 1000) print("Nose Z-force =", force0); #future breaking forces for gears
-#    if(force1 > 1200) print("Left Z-force =", force1); #1500 - 2000 lb seems plausible. Mind full load and cross wind landing
-#    if(force2 >1200)  print("Right Z-force =", force2);
-#    if(gear_side_force > 500) print ("left side-force =", gear_side_force);
-#    if(gear_side_force < -500) print ("right side-force =", abs(gear_side_force));
+#    # Future breaking forces for gears
+#    if (force0 > 1000) print("Nose Z-force =", force0);
+#
+#    # 1500 - 2000 lb seems plausible. Mind full load and cross wind landing
+#    if (force1 > 1200) print("Left Z-force =", force1);
+#
+#    if (force2 > 1200) print("Right Z-force =", force2);
+#    if (gear_side_force > 500) print ("left side-force =", gear_side_force);
+#    if (gear_side_force < -500) print ("right side-force =", abs(gear_side_force));
 
-	if(force0 > 1400)
-		nosegearbroke();
+    var bushkit = getprop("/fdm/jsbsim/bushkit");
+    var gears_broken = 0;
 
-	if(force1 > 2000 or gear_side_force > 1500)
-		leftgearbroke();
+	if (force0 > 1400) {
+		nosegearbroke(bushkit);
+		gears_broken += 1;
+    }
 
-	if(force2 > 2000 or gear_side_force < -1500)
-		rightgearbroke();
+	if (force1 > 2000 or gear_side_force > 1500) {
+		leftgearbroke(bushkit);
+		gears_broken += 1;
+    }
 
-	if(getprop(contact~"unit[13]/compression-ft") > 0.75 or getprop(contact~"unit[15]/compression-ft")  > 0.75 or getprop(contact~"unit[17]/compression-ft") > 0.75 or
-		getprop(gears~"unit[19]/compression-ft") > 0.75 or getprop(gears~"unit[21]/compression-ft")   > 0.75)
-		leftpontoondamaged();
+	if (force2 > 2000 or gear_side_force < -1500) {
+		rightgearbroke(bushkit);
+		gears_broken += 1;
+    }
 
-	if(getprop(contact~"unit[13]/compression-ft") > 0.95 or getprop(contact~"unit[15]/compression-ft")  > 0.95 or getprop(contact~"unit[17]/compression-ft") > 0.95 or
-		getprop(gears~"unit[19]/compression-ft") > 0.95 or getprop(gears~"unit[21]/compression-ft")   > 0.95)
-		leftpontoonbroke();
+    var unit_13_comp = getprop(contact~"unit[13]/compression-ft");
+    var unit_15_comp = getprop(contact~"unit[15]/compression-ft");
+    var unit_17_comp = getprop(contact~"unit[17]/compression-ft");
+    var unit_19_comp = getprop(gears~"unit[19]/compression-ft");
+    var unit_21_comp = getprop(gears~"unit[21]/compression-ft");
 
-	if(getprop(contact~"unit[14]/compression-ft") > 0.75 or getprop(contact~"unit[16]/compression-ft")  > 0.75 or getprop(contact~"unit[18]/compression-ft") > 0.75 or
-		getprop(gears~"unit[20]/compression-ft") > 0.75 or getprop(gears~"unit[22]/compression-ft")   > 0.75)
-		rightpontoondamaged();
+    var max_left_pontoon_gear_comp = std.max(unit_19_comp, unit_21_comp);
 
-	if(getprop(contact~"unit[14]/compression-ft") > 0.95 or getprop(contact~"unit[16]/compression-ft")  > 0.95 or getprop(contact~"unit[18]/compression-ft") > 0.95 or
-		getprop(gears~"unit[20]/compression-ft") > 0.95 or getprop(gears~"unit[22]/compression-ft")   > 0.95)
-		rightpontoonbroke();
+    # Left pontoon
+    if (unit_13_comp > 0.95 or unit_15_comp > 0.95 or unit_17_comp > 0.95 or
+		max_left_pontoon_gear_comp > 0.95)
+		leftpontoonbroke(bushkit);
+	elsif (unit_13_comp > 0.75 or unit_15_comp > 0.75 or unit_17_comp > 0.75 or
+		max_left_pontoon_gear_comp > 0.75)
+		leftpontoondamaged(bushkit);
 
-	# or getprop("/sim/rendering/leftwingdamage") or getprop("/sim/rendering/bothwingdamage")
-	if(getprop(contact~"unit[4]/compression-ft") > 0.005)
+    var unit_14_comp = getprop(contact~"unit[14]/compression-ft");
+    var unit_16_comp = getprop(contact~"unit[16]/compression-ft");
+    var unit_18_comp = getprop(contact~"unit[18]/compression-ft");
+    var unit_20_comp = getprop(gears~"unit[20]/compression-ft");
+    var unit_22_comp = getprop(gears~"unit[22]/compression-ft");
+
+    var max_right_pontoon_gear_comp = std.max(unit_20_comp, unit_22_comp);
+
+    # Right pontoon
+    if (unit_14_comp > 0.95 or unit_16_comp > 0.95 or unit_18_comp > 0.95 or
+		max_right_pontoon_gear_comp > 0.95)
+		rightpontoonbroke(bushkit);
+	elsif (unit_14_comp > 0.75 or unit_16_comp > 0.75 or unit_18_comp > 0.75 or
+		max_right_pontoon_gear_comp > 0.75)
+		rightpontoondamaged(bushkit);
+
+	if (getprop(contact~"unit[4]/compression-ft") > 0.005)
 		leftwingbroke();
 
-	# or getprop("/sim/rendering/rightwingdamage") or getprop("/sim/rendering/bothwingdamage")
-	if(getprop(contact~"unit[5]/compression-ft") > 0.005)
+	if (getprop(contact~"unit[5]/compression-ft") > 0.005)
 		rightwingbroke();
 
-	if(getprop(gears~"unit[0]/broken")	and getprop(gears~"unit[1]/broken")	and getprop(gears~"unit[2]/broken"))
-		if(!getprop("/fdm/jsbsim/wing-both/broken") and getprop("/fdm/jsbsim/wing-damage/left-wing") < 1 and getprop("/fdm/jsbsim/wing-damage/right-wing") < 1)
-			bothwingcollapse();
+    var left_wing_damage = getprop("/fdm/jsbsim/wing-damage/left-wing");
+    var right_wing_damage = getprop("/fdm/jsbsim/wing-damage/right-wing");
+    var crash = getprop("/fdm/jsbsim/crash");
+
+	if (gears_broken == 3 and !getprop("/fdm/jsbsim/wing-both/broken") and left_wing_damage < 1 and right_wing_damage < 1)
+		bothwingcollapse();
 
 	if (getprop(contact~"unit[12]/WOW"))
-		upsidedown();
+		upsidedown(left_wing_damage, right_wing_damage);
 
-	if(getprop("position/altitude-agl-m") < 10 and (getprop("/fdm/jsbsim/crash") or getprop("/fdm/jsbsim/wing-damage/left-wing") > 0.5 or getprop("/fdm/jsbsim/wing-damage/right-wing") > 0.5))
+	if (getprop("position/altitude-agl-m") < 10 and (crash or left_wing_damage > 0.5 or right_wing_damage > 0.5))
 		killengine();
 
-	if (getprop("/sim/rendering/allfix"))
-		resetalldamage();
+    # IN-FLIGHT DAMAGES
 
-#IN-FLIGHT DAMAGES
+    # Roll moment due to (diedra + roll rate + yaw rate + ailerons)
+    # => asymmetry to break one wing
+    var roll_moment = getprop(aero_coeff~"Clb")
+        + getprop(aero_coeff~"Clp")
+        + getprop(aero_coeff~"Clr")
+        + getprop(aero_coeff~"ClDa");
+#    print("Roll-moment: ", roll_moment);
 
-	roll_moment = getprop(aero_coeff~"Clb")+getprop(aero_coeff~"Clp")+getprop(aero_coeff~"Clr")+getprop(aero_coeff~"ClDa");
-	#print ("roll-moment=", roll_moment);
+    # Over-speed damages
+    var airspeed = getprop("velocities/airspeed-kt");
 
-#Over-speed	damages	 
-	if (getprop("velocities/airspeed-kt") > getprop("limits/vne"))
+    if (airspeed > limit_vne * 1.225) # Vne x sqrt(1.5) ~ 200 KIAS
 	{
-		if (roll_moment < -4000 and getprop("/fdm/jsbsim/wing-damage/left-wing") == 0)
+		if (!crash and left_wing_damage < 1 and right_wing_damage < 1)
+		{
+			bothwingsbroke();
+			gui.popupTip("Overspeed!! Both wings BROKEN", 5);
+		}
+	}
+	elsif (airspeed > limit_vne * 1.14) # 180 KIAS
+	{
+        if (roll_moment < -4000) {
+		    if (left_wing_damage < 0.5) {
+			    rightwingbroke();
+                gui.popupTip("Overspeed!! Right wing BROKEN", 5);
+            }
+		}
+		elsif (roll_moment > 4000) {
+		    if (right_wing_damage < 0.5) {
+			    leftwingbroke();
+                gui.popupTip("Overspeed!! Left wing BROKEN", 5);
+            }
+		}
+		else {
+		    if (left_wing_damage == 0 and right_wing_damage == 0) {
+			    setprop("/fdm/jsbsim/wing-damage/left-wing", 0.3);
+                setprop("/fdm/jsbsim/wing-damage/right-wing", 0.3);
+                gui.popupTip("Overspeed. Both wing DAMAGED", 5);
+		    }
+		}
+	}
+	elsif (airspeed > limit_vne)
+	{
+		if (roll_moment < -4000 and left_wing_damage == 0)
 		{
 			setprop("/fdm/jsbsim/wing-damage/right-wing", 0.12);
             gui.popupTip("Overspeed. Right wing DAMAGED!!", 5);
 		}
 		
-		if (roll_moment > 4000 and getprop("/fdm/jsbsim/wing-damage/right-wing") == 0)
+		if (roll_moment > 4000 and right_wing_damage == 0)
 		{
 			setprop("/fdm/jsbsim/wing-damage/left-wing", 0.12);
             gui.popupTip("Overspeed. Left wing DAMAGED!!", 5);
 		}
 	}        
 
-	if (getprop("velocities/airspeed-kt") > (getprop("limits/vne") * 1.14)) # 180 KIAS
-	{
-        if (roll_moment > -4000 and roll_moment < 4000 and getprop("/fdm/jsbsim/wing-damage/left-wing") == 0 and getprop("/fdm/jsbsim/wing-damage/right-wing") == 0)
-		{
-			setprop("/fdm/jsbsim/wing-damage/left-wing", 0.3);
-            setprop("/fdm/jsbsim/wing-damage/right-wing", 0.3);
-            gui.popupTip("Overspeed. Both wing DAMAGED", 5);
-		}
-        if (roll_moment < -4000 and getprop("/fdm/jsbsim/wing-damage/left-wing") < 0.5)
-		{
-			rightwingbroke();
-            gui.popupTip("Overspeed!! Right wing BROKEN", 5);
-		}
-		
-		if (roll_moment > 4000 and getprop("/fdm/jsbsim/wing-damage/right-wing") < 0.5)
-		{
-			leftwingbroke();
-            gui.popupTip("Overspeed!! Left wing BROKEN", 5);
-		}
-	}
-		
-	if (getprop("velocities/airspeed-kt") > (getprop("limits/vne") * 1.225)) # Vne x sqrt(1.5) ~ 200 KIAS
-	{    
-		if (getprop("/fdm/jsbsim/wing-damage/left-wing") < 1 and getprop("/fdm/jsbsim/wing-damage/right-wing") < 1)
-		{
-				if (!getprop("/fdm/jsbsim/crash"))
-				{
-					bothwingsbroke();
-					gui.popupTip("Overspeed!! Both wings BROKEN", 5);
-				}
-		}
-	}
-	
-#Over-g damages, over-forces on wings
+    # Over-g damages, over-forces on wings
 
-    lift_force = -getprop("/fdm/jsbsim/forces/fbz-aero-lbs");
-    
-    if (lift_force > max_lift_force)
+    var lift_force = -getprop("/fdm/jsbsim/forces/fbz-aero-lbs");
+
+    if (lift_force > max_lift_force * 1.5)
 	{
-#        print("Lift-Force =", lift_force);
-		if (roll_moment < -4000 and getprop("/fdm/jsbsim/wing-damage/left-wing") == 0)
+		if (!crash)
 		{
-			setprop("/fdm/jsbsim/wing-damage/right-wing", 0.12);
-            gui.popupTip("Over-load Right wing DAMAGED!!", 5);
-		}
-		if (roll_moment > 4000 and getprop("/fdm/jsbsim/wing-damage/right-wing") == 0)
-		{
-			setprop("/fdm/jsbsim/wing-damage/left-wing", 0.12);
-            gui.popupTip("Over-load Left wing DAMAGED!!", 5);
+			bothwingsbroke();
+			gui.popupTip("Over-load Both wings BROKEN!!", 5);
 		}
 	}
-    if (lift_force > (max_lift_force * 1.25))
+	elsif (lift_force > max_lift_force * 1.25)
 	{
-		if (roll_moment < -4000 and getprop("/fdm/jsbsim/wing-damage/left-wing") < 1)
+		if (roll_moment < -4000 and left_wing_damage < 1)
 		{
 			rightwingbroke();
             gui.popupTip("Over-load Right wing BROKEN", 5);
 		}
-		if (roll_moment > 4000 and getprop("/fdm/jsbsim/wing-damage/right-wing") < 1)
+		if (roll_moment > 4000 and right_wing_damage < 1)
 		{
 			leftwingbroke();
             gui.popupTip("Over-load Left wing BROKEN", 5);
 		}
 	}
-    if (lift_force > (max_lift_force * 1.5))
+    elsif (lift_force > max_lift_force)
 	{
-		if (!getprop("/fdm/jsbsim/crash"))
+#        print("Lift-Force: ", lift_force);
+		if (roll_moment < -4000 and left_wing_damage == 0)
 		{
-			bothwingsbroke();
-			gui.popupTip("Over-load Both wings BROKEN!!", 5);
+			setprop("/fdm/jsbsim/wing-damage/right-wing", 0.12);
+            gui.popupTip("Over-load Right wing DAMAGED!!", 5);
 		}
-	}	
+		if (roll_moment > 4000 and right_wing_damage == 0)
+		{
+			setprop("/fdm/jsbsim/wing-damage/left-wing", 0.12);
+            gui.popupTip("Over-load Left wing DAMAGED!!", 5);
+		}
+	}
 }
 
-#check if on water
+# Check if on water
 var poll_surface = func
 {
-	if (getprop("/fdm/jsbsim/hydro/active-norm") > 0)
-		if (.005*(.065*getprop("fdm/jsbsim/propulsion/engine/engine-rpm")) > (.005*getprop("velocities/groundspeed-kt")))
-			setprop("/environment/aircraft-effects/ground-splash-norm", (.005*(.065*getprop("fdm/jsbsim/propulsion/engine/engine-rpm"))));
-		else
-			setprop("/environment/aircraft-effects/ground-splash-norm", (.005*getprop("velocities/groundspeed-kt")));
+    var engine_rpm = getprop("fdm/jsbsim/propulsion/engine/engine-rpm");
+    var hydro_active_norm = getprop("/fdm/jsbsim/hydro/active-norm");
+    var ground_splash_norm = getprop("/environment/aircraft-effects/ground-splash-norm");
 
-	if (getprop("position/altitude-agl-m") > 2 or getprop("/fdm/jsbsim/hydro/active-norm") == 0)
-	    if (getprop("/environment/aircraft-effects/ground-splash-norm") > 0)
-		    setprop("/environment/aircraft-effects/ground-splash-norm", getprop("/environment/aircraft-effects/ground-splash-norm") - .005);
+    # Use engine RPM and speed to control ground splash if on the water
+    # and below 2 meter AGL
+	if (getprop("position/altitude-agl-m") < 2 and hydro_active_norm > 0) {
+	    var groundspeed_half_pc = 0.005 * getprop("velocities/groundspeed-kt");
+        var engine_rpm_almost_nothing = 0.005 * 0.065 * engine_rpm;
 
-	if (!getprop(contact~"unit[12]/solid"))
-		setprop(contact~"unit[12]/z-position", 160);
-	else
-		setprop(contact~"unit[12]/z-position", 90);
+	    var splash_norm = std.max(engine_rpm_almost_nothing, groundspeed_half_pc);
+	    setprop("/environment/aircraft-effects/ground-splash-norm", splash_norm);
+	}
+	elsif (ground_splash_norm > 0)
+	    setprop("/environment/aircraft-effects/ground-splash-norm", ground_splash_norm - 0.005);
 
-	if (!getprop(contact~"unit[4]/solid"))
-		setprop(contact~"unit[4]/z-position", -10);
-	else
-		setprop(contact~"unit[4]/z-position", 50);
-
-	if (!getprop(contact~"unit[5]/solid"))
-		setprop(contact~"unit[5]/z-position", -10);
-	else
-		setprop(contact~"unit[5]/z-position", 50);
-
-	if (!getprop(contact~"unit[9]/solid"))
-		setprop(contact~"unit[9]/z-position", -25);
-	else
-		setprop(contact~"unit[9]/z-position", 35);
-
-	if (!getprop(contact~"unit[10]/solid"))
-		setprop(contact~"unit[10]/z-position", -25);
-	else
-		setprop(contact~"unit[10]/z-position", 8);
-
-	if (!getprop(contact~"unit[11]/solid"))
-		setprop(contact~"unit[11]/z-position", -25);
-	else
-		setprop(contact~"unit[11]/z-position", 60);
+    setprop(contact~"unit[12]/z-position", !getprop(contact~"unit[12]/solid") ? 160 : 90);
+    setprop(contact~"unit[4]/z-position", !getprop(contact~"unit[4]/solid") ? -10 : 50);
+    setprop(contact~"unit[5]/z-position", !getprop(contact~"unit[5]/solid") ? -10 : 50);
+    setprop(contact~"unit[9]/z-position", !getprop(contact~"unit[9]/solid") ? -25 : 35);
+    setprop(contact~"unit[10]/z-position", !getprop(contact~"unit[10]/solid") ? -25 : 8);
+    setprop(contact~"unit[11]/z-position", !getprop(contact~"unit[11]/solid") ? -25 : 60);
 }
 
 var changing_bushkit = 0;
@@ -467,6 +460,10 @@ var physics_loop = func
 }
 
 var set_bushkit = func (bushkit) {
+    resetalldamage();
+	resetcontacts();
+
+    # Reset z-position's
     if (bushkit == 0)
         defaulttires();
     elsif (bushkit == 1)

--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -297,7 +297,7 @@ var poll_damage = func
     var left_wing_damage = getprop("/fdm/jsbsim/wing-damage/left-wing");
     var right_wing_damage = getprop("/fdm/jsbsim/wing-damage/right-wing");
 
-	if (gears_broken == 3 and left_wing_damage != 1 and right_wing_damage != 1)
+	if (gears_broken == 3 and left_wing_damage < 1 and right_wing_damage < 1)
 		bothwingcollapse();
 
     var crash = getprop("/fdm/jsbsim/crash");
@@ -305,7 +305,7 @@ var poll_damage = func
 	if (getprop(contact~"unit[12]/WOW"))
 		upsidedown();
 
-	if (getprop("position/altitude-agl-m") < 10 and (crash or left_wing_damage == 1 or right_wing_damage == 1))
+	if (getprop("position/altitude-agl-m") < 10 and (crash or left_wing_damage > 0.5 or right_wing_damage > 0.5))
 		killengine();
 
     # IN-FLIGHT DAMAGES
@@ -323,7 +323,7 @@ var poll_damage = func
 
     if (airspeed > limit_vne * 1.225) # Vne x sqrt(1.5) ~ 200 KIAS
 	{
-		if (!crash and left_wing_damage != 1 and right_wing_damage != 1)
+		if (!crash and left_wing_damage < 1 and right_wing_damage < 1)
 		{
 			bothwingsbroke();
 			gui.popupTip("Overspeed!! Both wings BROKEN", 5);
@@ -332,21 +332,21 @@ var poll_damage = func
 	elsif (airspeed > limit_vne * 1.14) # 180 KIAS
 	{
         if (roll_moment < -4000) {
-		    if (left_wing_damage == 0 or left_wing_damage == 2) {
+		    if (left_wing_damage < 0.5) {
 			    rightwingbroke();
                 gui.popupTip("Overspeed!! Right wing BROKEN", 5);
             }
 		}
 		elsif (roll_moment > 4000) {
-		    if (right_wing_damage == 0 or right_wing_damage == 2) {
+		    if (right_wing_damage < 0.5) {
 			    leftwingbroke();
                 gui.popupTip("Overspeed!! Left wing BROKEN", 5);
             }
 		}
 		else {
 		    if (left_wing_damage == 0 and right_wing_damage == 0) {
-			    setprop("/fdm/jsbsim/wing-damage/left-wing", 3);
-                setprop("/fdm/jsbsim/wing-damage/right-wing", 3);
+			    setprop("/fdm/jsbsim/wing-damage/left-wing", 0.3);
+                setprop("/fdm/jsbsim/wing-damage/right-wing", 0.3);
                 gui.popupTip("Overspeed. Both wing DAMAGED", 5);
 		    }
 		}
@@ -355,13 +355,13 @@ var poll_damage = func
 	{
 		if (roll_moment < -4000 and left_wing_damage == 0)
 		{
-			setprop("/fdm/jsbsim/wing-damage/right-wing", 2);
+			setprop("/fdm/jsbsim/wing-damage/right-wing", 0.12);
             gui.popupTip("Overspeed. Right wing DAMAGED!!", 5);
 		}
 		
 		if (roll_moment > 4000 and right_wing_damage == 0)
 		{
-			setprop("/fdm/jsbsim/wing-damage/left-wing", 2);
+			setprop("/fdm/jsbsim/wing-damage/left-wing", 0.12);
             gui.popupTip("Overspeed. Left wing DAMAGED!!", 5);
 		}
 	}        
@@ -380,12 +380,12 @@ var poll_damage = func
 	}
 	elsif (lift_force > max_lift_force * 1.25)
 	{
-		if (roll_moment < -4000 and left_wing_damage != 1)
+		if (roll_moment < -4000 and left_wing_damage < 1)
 		{
 			rightwingbroke();
             gui.popupTip("Over-load Right wing BROKEN", 5);
 		}
-		if (roll_moment > 4000 and right_wing_damage != 1)
+		if (roll_moment > 4000 and right_wing_damage < 1)
 		{
 			leftwingbroke();
             gui.popupTip("Over-load Left wing BROKEN", 5);
@@ -396,12 +396,12 @@ var poll_damage = func
 #        print("Lift-Force: ", lift_force);
 		if (roll_moment < -4000 and left_wing_damage == 0)
 		{
-			setprop("/fdm/jsbsim/wing-damage/right-wing", 2);
+			setprop("/fdm/jsbsim/wing-damage/right-wing", 0.12);
             gui.popupTip("Over-load Right wing DAMAGED!!", 5);
 		}
 		if (roll_moment > 4000 and right_wing_damage == 0)
 		{
-			setprop("/fdm/jsbsim/wing-damage/left-wing", 2);
+			setprop("/fdm/jsbsim/wing-damage/left-wing", 0.12);
             gui.popupTip("Over-load Left wing DAMAGED!!", 5);
 		}
 	}

--- a/Systems/als-lights.xml
+++ b/Systems/als-lights.xml
@@ -20,16 +20,41 @@
 <PropertyList>
 
     <logic>
-        <name>ALS Lighting Landing</name>
+        <name>Lighting Landing On/Off</name>
         <input>
             <and>
-                <property>/sim/current-view/internal</property>
                 <less-than>
                     <property>/systems/electrical/outputs/landing-lights</property>
                     <value>31.5</value>
                 </less-than>
                 <greater-than>
                     <property>/systems/electrical/outputs/landing-lights</property>
+                    <value>20.0</value>
+                </greater-than>
+			    <not>
+				    <property>/fdm/jsbsim/contact/unit[4]/broken</property>
+			    </not>
+                <less-than>
+                    <property>/fdm/jsbsim/wing-damage/left-wing</property>
+                    <value>1.0</value>
+                </less-than>
+            </and>
+        </input>
+        <output>
+            <property>/sim/model/c172p/lighting/landing</property>
+        </output>
+    </logic>
+
+    <logic>
+        <name>Lighting Taxi On/Off</name>
+        <input>
+            <and>
+                <less-than>
+                    <property>/systems/electrical/outputs/taxi-light</property>
+                    <value>31.5</value>
+                </less-than>
+                <greater-than>
+                    <property>/systems/electrical/outputs/taxi-light</property>
                     <value>20.0</value>
                 </greater-than>
 				<not>
@@ -42,6 +67,19 @@
             </and>
         </input>
         <output>
+            <property>/sim/model/c172p/lighting/taxi</property>
+        </output>
+    </logic>
+
+    <logic>
+        <name>ALS Lighting Landing</name>
+        <input>
+            <and>
+                <property>/sim/current-view/internal</property>
+                <property>/sim/model/c172p/lighting/landing</property>
+            </and>
+        </input>
+        <output>
             <property>/sim/rendering/als-secondary-lights/use-landing-light</property>
         </output>
     </logic>
@@ -51,21 +89,7 @@
         <input>
             <and>
                 <property>/sim/current-view/internal</property>
-                <less-than>
-                    <property>/systems/electrical/outputs/taxi-light</property>
-                    <value>31.5</value>
-                </less-than>
-                <greater-than>
-                    <property>/systems/electrical/outputs/taxi-light</property>
-                    <value>20.0</value>
-                </greater-than>
-				<not>
-					<property>/fdm/jsbsim/contact/unit[4]/broken</property>
-				</not>
-                <less-than>
-                    <property>/fdm/jsbsim/wing-damage/left-wing</property>
-                    <value>1.0</value>
-                </less-than>
+                <property>/sim/model/c172p/lighting/taxi</property>
             </and>
         </input>
         <output>

--- a/Systems/als-lights.xml
+++ b/Systems/als-lights.xml
@@ -35,9 +35,10 @@
 				<not>
 					<property>/fdm/jsbsim/contact/unit[4]/broken</property>
 				</not>
-				<not>
-					<property>/fdm/jsbsim/wing-both/broken</property>
-				</not>
+                <less-than>
+                    <property>/fdm/jsbsim/wing-damage/left-wing</property>
+                    <value>1.0</value>
+                </less-than>
             </and>
         </input>
         <output>
@@ -61,9 +62,10 @@
 				<not>
 					<property>/fdm/jsbsim/contact/unit[4]/broken</property>
 				</not>
-				<not>
-					<property>/fdm/jsbsim/wing-both/broken</property>
-				</not>
+                <less-than>
+                    <property>/fdm/jsbsim/wing-damage/left-wing</property>
+                    <value>1.0</value>
+                </less-than>
             </and>
         </input>
         <output>

--- a/Systems/als-lights.xml
+++ b/Systems/als-lights.xml
@@ -19,6 +19,12 @@
 
 <PropertyList>
 
+    <!--
+        Note: Properties in /systems/electrical/ are computed by
+        Nasal/electrical.nas during replay, thus do not need to be
+        recorded.
+    -->
+
     <logic>
         <name>Lighting Landing On/Off</name>
         <input>
@@ -31,13 +37,10 @@
                     <property>/systems/electrical/outputs/landing-lights</property>
                     <value>20.0</value>
                 </greater-than>
-			    <not>
-				    <property>/fdm/jsbsim/contact/unit[4]/broken</property>
-			    </not>
-                <less-than>
-                    <property>/fdm/jsbsim/wing-damage/left-wing</property>
-                    <value>1.0</value>
-                </less-than>
+                <not-equals>
+                    <property>/sim/model/c172p/damage/left-wing</property>
+                    <value>1</value>
+                </not-equals>
             </and>
         </input>
         <output>
@@ -57,13 +60,10 @@
                     <property>/systems/electrical/outputs/taxi-light</property>
                     <value>20.0</value>
                 </greater-than>
-				<not>
-					<property>/fdm/jsbsim/contact/unit[4]/broken</property>
-				</not>
-                <less-than>
-                    <property>/fdm/jsbsim/wing-damage/left-wing</property>
-                    <value>1.0</value>
-                </less-than>
+                <not-equals>
+                    <property>/sim/model/c172p/damage/left-wing</property>
+                    <value>1</value>
+                </not-equals>
             </and>
         </input>
         <output>

--- a/Systems/bushkit.xml
+++ b/Systems/bushkit.xml
@@ -295,4 +295,34 @@ Extra weight and drag due to bush wheels, floats and 180 hp engine
 
     </channel>
 
+    <channel name="wing-damage">
+
+        <switch>
+            <default value="0"/>
+            <output>/sim/model/c172p/damage/left-wing</output>
+
+            <test logic="AND" value="1">
+                wing-damage/left-wing eq 1.0
+            </test>
+            <test logic="AND" value="2">
+                wing-damage/left-wing gt 0.0
+                wing-damage/left-wing lt 1.0
+            </test>
+        </switch>
+
+        <switch>
+            <default value="0"/>
+            <output>/sim/model/c172p/damage/right-wing</output>
+
+            <test logic="AND" value="1">
+                wing-damage/right-wing eq 1.0
+            </test>
+            <test logic="AND" value="2">
+                wing-damage/right-wing gt 0.0
+                wing-damage/right-wing lt 1.0
+            </test>
+        </switch>
+
+    </channel>
+
 </system>

--- a/Systems/bushkit.xml
+++ b/Systems/bushkit.xml
@@ -295,34 +295,4 @@ Extra weight and drag due to bush wheels, floats and 180 hp engine
 
     </channel>
 
-    <channel name="wing-damage">
-
-        <switch>
-            <default value="0"/>
-            <output>/sim/model/c172p/damage/left-wing</output>
-
-            <test logic="AND" value="1">
-                wing-damage/left-wing eq 1.0
-            </test>
-            <test logic="AND" value="2">
-                wing-damage/left-wing gt 0.0
-                wing-damage/left-wing lt 1.0
-            </test>
-        </switch>
-
-        <switch>
-            <default value="0"/>
-            <output>/sim/model/c172p/damage/right-wing</output>
-
-            <test logic="AND" value="1">
-                wing-damage/right-wing eq 1.0
-            </test>
-            <test logic="AND" value="2">
-                wing-damage/right-wing gt 0.0
-                wing-damage/right-wing lt 1.0
-            </test>
-        </switch>
-
-    </channel>
-
 </system>

--- a/Systems/bushkit.xml
+++ b/Systems/bushkit.xml
@@ -240,15 +240,13 @@ Extra weight and drag due to bush wheels, floats and 180 hp engine
         <fcs_function name="left-pontoon/leakage-lbs_sec">
             <function>
                 <product>
-                    <value>5.0</value>
                     <property>hydro/active-norm</property>
-                    <sum>
-                        <property>left-pontoon/damaged</property>
-                        <product>
-                            <value>50.0</value>
-                            <property>left-pontoon/broken</property>
-                        </product>
-                    </sum>
+                    <switch>
+                        <property>pontoon-damage/left-pontoon</property>
+                        <value>0.0</value>
+                        <value>250.0</value>
+                        <value>5.0</value>
+                    </switch>
                 </product>
             </function>
         </fcs_function>
@@ -268,15 +266,13 @@ Extra weight and drag due to bush wheels, floats and 180 hp engine
         <fcs_function name="right-pontoon/leakage-lbs_sec">
             <function>
                 <product>
-                    <value>5.0</value>
                     <property>hydro/active-norm</property>
-                    <sum>
-                        <property>right-pontoon/damaged</property>
-                        <product>
-                            <value>50.0</value>
-                            <property>right-pontoon/broken</property>
-                        </product>
-                    </sum>
+                    <switch>
+                        <property>pontoon-damage/right-pontoon</property>
+                        <value>0.0</value>
+                        <value>250.0</value>
+                        <value>5.0</value>
+                    </switch>
                 </product>
             </function>
         </fcs_function>

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -77,7 +77,7 @@
 
         <switch>
             <output>gear/unit[0]/broken</output>
-            <default value="0"/>
+            <default value="gear/unit[0]/broken"/>
 
             <test logic="AND" value="1">
                 damage/force-nose-gear GT 1500.0
@@ -86,16 +86,11 @@
                 damage/repairing EQ 0
                 simulation/sim-time-sec GT 0.25
             </test>
-
-            <!-- Keep nose gear broken once it breaks -->
-            <test logic="AND" value="1">
-                gear/unit[0]/broken EQ 1
-            </test>
         </switch>
 
         <switch>
             <output>gear/unit[1]/broken</output>
-            <default value="0"/>
+            <default value="gear/unit[1]/broken"/>
 
             <!-- [1] used to guess required force -->
             <test logic="AND" value="1">
@@ -114,16 +109,11 @@
                 damage/repairing EQ 0
                 simulation/sim-time-sec GT 0.25
             </test>
-
-            <!-- Keep left gear broken once it breaks -->
-            <test logic="AND" value="1">
-                gear/unit[1]/broken EQ 1
-            </test>
         </switch>
 
         <switch>
             <output>gear/unit[2]/broken</output>
-            <default value="0"/>
+            <default value="gear/unit[2]/broken"/>
 
             <!-- [1] used to guess required force -->
             <test logic="AND" value="1">
@@ -142,11 +132,6 @@
                 damage/repairing EQ 0
                 simulation/sim-time-sec GT 0.25
             </test>
-
-            <!-- Keep right gear broken once it breaks -->
-            <test logic="AND" value="1">
-                gear/unit[2]/broken EQ 1
-            </test>
         </switch>
 
     </channel>
@@ -164,6 +149,106 @@
                 </sum>
             </function>
         </fcs_function>
+
+        <pure_gain name="damage/limits-vne-high">
+            <input>/limits/vne</input>
+            <gain>1.225</gain>
+        </pure_gain>
+
+        <pure_gain name="damage/limits-vne-medium">
+            <input>/limits/vne</input>
+            <gain>1.14</gain>
+        </pure_gain>
+
+        <!-- Left wing broken -->
+        <switch>
+            <output>contact/unit[4]/broken</output>
+            <default value="contact/unit[4]/broken"/>
+
+            <test logic="AND" value="1">
+                contact/unit[4]/compression-ft GT 0.005
+            </test>
+
+            <test logic="AND" value="1">
+                /velocities/airspeed-kt GT damage/limits-vne-high
+                crash EQ 0
+                wing-damage/left-wing LT 1.0
+            </test>
+
+            <test logic="AND" value="1">
+                /velocities/airspeed-kt GT damage/limits-vne-medium
+                damage/roll-moment GT 4000.0
+                wing-damage/right-wing LT 0.5<!-- Change to wing-damage/left-wing LT 0.5? -->
+            </test>
+        </switch>
+
+        <!-- Left wing damage -->
+        <switch>
+            <output>wing-damage/left-wing</output>
+            <default value="wing-damage/left-wing"/>
+
+            <test logic="AND" value="1.0">
+                contact/unit[4]/broken EQ 1
+            </test>
+
+            <test logic="AND" value="0.3">
+                /velocities/airspeed-kt GT damage/limits-vne-medium
+                damage/roll-moment LT 4000.0
+                damage/roll-moment GT -4000.0
+                wing-damage/left-wing EQ 0.0<!-- Change to wing-damage/left-wing LT 0.3? -->
+            </test>
+
+            <test logic="AND" value="0.12">
+                /velocities/airspeed-kt GT /limits/vne
+                damage/roll-moment GT 4000.0
+                wing-damage/right-wing EQ 0.0<!-- Change to wing-damage/left-wing LT 0.12? -->
+            </test>
+        </switch>
+
+        <!-- Right wing broken -->
+        <switch>
+            <output>contact/unit[5]/broken</output>
+            <default value="contact/unit[5]/broken"/>
+
+            <test logic="AND" value="1">
+                contact/unit[5]/compression-ft GT 0.005
+            </test>
+
+            <test logic="AND" value="1">
+                /velocities/airspeed-kt GT damage/limits-vne-high
+                crash EQ 0
+                wing-damage/right-wing LT 1.0
+            </test>
+
+            <test logic="AND" value="1">
+                /velocities/airspeed-kt GT damage/limits-vne-medium
+                damage/roll-moment LT -4000.0
+                wing-damage/left-wing LT 0.5<!-- Change to wing-damage/right-wing LT 0.5? -->
+            </test>
+        </switch>
+
+        <!-- Right wing damage -->
+        <switch>
+            <output>wing-damage/right-wing</output>
+            <default value="wing-damage/right-wing"/>
+
+            <test logic="AND" value="1.0">
+                contact/unit[5]/broken EQ 1
+            </test>
+
+            <test logic="AND" value="0.3">
+                /velocities/airspeed-kt GT damage/limits-vne-medium
+                damage/roll-moment LT 4000.0
+                damage/roll-moment GT -4000.0
+                wing-damage/right-wing EQ 0.0<!-- Change to wing-damage/right-wing LT 0.3? -->
+            </test>
+
+            <test logic="AND" value="0.12">
+                /velocities/airspeed-kt GT /limits/vne
+                damage/roll-moment LT -4000.0
+                wing-damage/left-wing EQ 0.0<!-- Change to wing-damage/right-wing LT 0.12? -->
+            </test>
+        </switch>
 
     </channel>
 

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -365,4 +365,98 @@
 
     </channel>
 
+    <channel name="pontoon-damage">
+
+        <!-- Left pontoon damage -->
+        <switch>
+            <output>pontoon-damage/left-pontoon</output>
+            <default value="pontoon-damage/left-pontoon"/>
+
+            <!-- No damage -->
+            <test logic="OR" value="0">
+                settings/damage EQ 0
+                damage/repairing EQ 1
+                simulation/sim-time-sec LT 0.25
+            </test>
+            <test logic="AND" value="0">
+                bushkit NE 3
+                bushkit NE 4
+            </test>
+
+            <!-- ================================================================== -->
+            <!-- Broken                                                             -->
+            <!-- ================================================================== -->
+
+            <test logic="OR" value="1">
+                contact/unit[13]/compression-ft GT 0.95
+                contact/unit[15]/compression-ft GT 0.95
+                contact/unit[17]/compression-ft GT 0.95
+                gear/unit[19]/compression-ft GT 0.95
+                gear/unit[21]/compression-ft GT 0.95
+            </test>
+
+            <!-- ================================================================== -->
+            <!-- Damaged                                                            -->
+            <!-- ================================================================== -->
+
+            <test logic="AND" value="pontoon-damage/left-pontoon">
+                pontoon-damage/left-pontoon NE 1
+
+                <test logic="OR" value="2">
+                    contact/unit[13]/compression-ft GT 0.75
+                    contact/unit[15]/compression-ft GT 0.75
+                    contact/unit[17]/compression-ft GT 0.75
+                    gear/unit[19]/compression-ft GT 0.75
+                    gear/unit[21]/compression-ft GT 0.75
+                </test>
+            </test>
+        </switch>
+
+        <!-- Right pontoon damage -->
+        <switch>
+            <output>pontoon-damage/right-pontoon</output>
+            <default value="pontoon-damage/right-pontoon"/>
+
+            <!-- No damage -->
+            <test logic="OR" value="0">
+                settings/damage EQ 0
+                damage/repairing EQ 1
+                simulation/sim-time-sec LT 0.25
+            </test>
+            <test logic="AND" value="0">
+                bushkit NE 3
+                bushkit NE 4
+            </test>
+
+            <!-- ================================================================== -->
+            <!-- Broken                                                             -->
+            <!-- ================================================================== -->
+
+            <test logic="OR" value="1">
+                contact/unit[14]/compression-ft GT 0.95
+                contact/unit[16]/compression-ft GT 0.95
+                contact/unit[18]/compression-ft GT 0.95
+                gear/unit[20]/compression-ft GT 0.95
+                gear/unit[22]/compression-ft GT 0.95
+            </test>
+
+            <!-- ================================================================== -->
+            <!-- Damaged                                                            -->
+            <!-- ================================================================== -->
+
+            <test logic="AND" value="pontoon-damage/right-pontoon">
+                pontoon-damage/right-pontoon NE 1
+
+                <test logic="OR" value="2">
+                    contact/unit[14]/compression-ft GT 0.75
+                    contact/unit[16]/compression-ft GT 0.75
+                    contact/unit[18]/compression-ft GT 0.75
+                    gear/unit[20]/compression-ft GT 0.75
+                    gear/unit[22]/compression-ft GT 0.75
+                </test>
+            </test>
+        </switch>
+
+    </channel>
+
 </system>

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -21,7 +21,7 @@
     <channel name="gear-forces">
 
         <!--
-             References:
+            References:
                 [1] https://www.youtube.com/watch?v=O1yWkbJuqkE#t=420
         -->
 
@@ -150,47 +150,85 @@
             </function>
         </fcs_function>
 
+        <!-- Limits for overspeed damage -->
         <pure_gain name="damage/limits-vne-high">
             <input>/limits/vne</input>
             <gain>1.225</gain>
         </pure_gain>
-
         <pure_gain name="damage/limits-vne-medium">
             <input>/limits/vne</input>
             <gain>1.14</gain>
         </pure_gain>
+        <pure_gain name="damage/limits-vne-low">
+            <input>/limits/vne</input>
+            <gain>1.0</gain>
+        </pure_gain>
 
-        <!-- Left wing broken -->
-        <switch>
-            <output>contact/unit[4]/broken</output>
-            <default value="contact/unit[4]/broken"/>
+        <!-- Limits for over-g damage -->
+        <pure_gain name="damage/limits-lift-high">
+            <input>/limits/max-lift-force</input>
+            <gain>1.75</gain>
+        </pure_gain>
+        <pure_gain name="damage/limits-lift-medium">
+            <input>/limits/max-lift-force</input>
+            <gain>1.4</gain>
+        </pure_gain>
+        <pure_gain name="damage/limits-lift-low">
+            <input>/limits/max-lift-force</input>
+            <gain>1.0</gain>
+        </pure_gain>
 
-            <test logic="AND" value="1">
-                contact/unit[4]/compression-ft GT 0.005
-            </test>
-
-            <test logic="AND" value="1">
-                /velocities/airspeed-kt GT damage/limits-vne-high
-                crash EQ 0
-                wing-damage/left-wing LT 1.0
-            </test>
-
-            <test logic="AND" value="1">
-                /velocities/airspeed-kt GT damage/limits-vne-medium
-                damage/roll-moment GT 4000.0
-                wing-damage/right-wing LT 0.5<!-- Change to wing-damage/left-wing LT 0.5? -->
-            </test>
-        </switch>
+        <pure_gain name="damage/force-aero-lbs">
+            <input>forces/fbz-aero-lbs</input>
+            <gain>-1.0</gain>
+        </pure_gain>
 
         <!-- Left wing damage -->
         <switch>
             <output>wing-damage/left-wing</output>
             <default value="wing-damage/left-wing"/>
 
+            <!-- Break wing when its wing tip hits the ground or an object -->
             <test logic="AND" value="1.0">
-                contact/unit[4]/broken EQ 1
+                contact/unit[4]/compression-ft GT 0.005
             </test>
 
+            <!-- Overspeed broken -->
+            <test logic="AND" value="1.0">
+                /velocities/airspeed-kt GT damage/limits-vne-high
+                crash EQ 0
+                wing-damage/left-wing LT 1.0
+            </test>
+
+            <!-- Overspeed broken -->
+            <test logic="AND" value="1.0">
+                /velocities/airspeed-kt GT damage/limits-vne-medium
+                damage/roll-moment GT 4000.0
+                wing-damage/right-wing LT 0.5<!-- Change to wing-damage/left-wing LT 0.5? -->
+            </test>
+
+            <!-- Over-g broken -->
+            <test logic="AND" value="1.0">
+                damage/force-aero-lbs GT damage/limits-lift-high
+                crash EQ 0
+            </test>
+
+            <!-- Over-g broken -->
+            <test logic="AND" value="1.0">
+                damage/force-aero-lbs GT damage/limits-lift-medium
+                damage/roll-moment GT 4000.0
+                wing-damage/right-wing LT 1.0<!-- Change to wing-damage/left-wing LT 1.0? -->
+            </test>
+
+            <!-- Over-g damage -->
+            <test logic="AND" value="0.3">
+                damage/force-aero-lbs GT damage/limits-lift-medium
+                damage/roll-moment LT 4000.0
+                damage/roll-moment GT -4000.0
+                wing-damage/right-wing LT 0.3<!-- Change to wing-damage/left-wing LT 0.3? -->
+            </test>
+
+            <!-- Overspeed damage -->
             <test logic="AND" value="0.3">
                 /velocities/airspeed-kt GT damage/limits-vne-medium
                 damage/roll-moment LT 4000.0
@@ -198,32 +236,26 @@
                 wing-damage/left-wing EQ 0.0<!-- Change to wing-damage/left-wing LT 0.3? -->
             </test>
 
+            <!-- Overspeed damage -->
             <test logic="AND" value="0.12">
-                /velocities/airspeed-kt GT /limits/vne
+                /velocities/airspeed-kt GT damage/limits-vne-low
                 damage/roll-moment GT 4000.0
                 wing-damage/right-wing EQ 0.0<!-- Change to wing-damage/left-wing LT 0.12? -->
             </test>
-        </switch>
 
-        <!-- Right wing broken -->
-        <switch>
-            <output>contact/unit[5]/broken</output>
-            <default value="contact/unit[5]/broken"/>
-
-            <test logic="AND" value="1">
-                contact/unit[5]/compression-ft GT 0.005
+            <!-- Over-g damage -->
+            <test logic="AND" value="0.12">
+                damage/force-aero-lbs GT damage/limits-lift-medium
+                damage/roll-moment LT 4000.0
+                damage/roll-moment GT -4000.0
+                wing-damage/right-wing EQ 0.0<!-- Change to wing-damage/left-wing EQ 0.0? -->
             </test>
 
-            <test logic="AND" value="1">
-                /velocities/airspeed-kt GT damage/limits-vne-high
-                crash EQ 0
-                wing-damage/right-wing LT 1.0
-            </test>
-
-            <test logic="AND" value="1">
-                /velocities/airspeed-kt GT damage/limits-vne-medium
-                damage/roll-moment LT -4000.0
-                wing-damage/left-wing LT 0.5<!-- Change to wing-damage/right-wing LT 0.5? -->
+            <!-- Over-g damage -->
+            <test logic="AND" value="0.12">
+                damage/force-aero-lbs GT damage/limits-lift-low
+                damage/roll-moment GT 4000.0
+                wing-damage/right-wing EQ 0.0<!-- Change to wing-damage/left-wing EQ 0.0? -->
             </test>
         </switch>
 
@@ -232,10 +264,47 @@
             <output>wing-damage/right-wing</output>
             <default value="wing-damage/right-wing"/>
 
+            <!-- Break wing when its wing tip hits the ground or an object -->
             <test logic="AND" value="1.0">
-                contact/unit[5]/broken EQ 1
+                contact/unit[5]/compression-ft GT 0.005
             </test>
 
+            <!-- Overspeed broken -->
+            <test logic="AND" value="1.0">
+                /velocities/airspeed-kt GT damage/limits-vne-high
+                crash EQ 0
+                wing-damage/right-wing LT 1.0
+            </test>
+
+            <!-- Overspeed broken -->
+            <test logic="AND" value="1.0">
+                /velocities/airspeed-kt GT damage/limits-vne-medium
+                damage/roll-moment LT -4000.0
+                wing-damage/left-wing LT 0.5<!-- Change to wing-damage/right-wing LT 0.5? -->
+            </test>
+
+            <!-- Over-g broken -->
+            <test logic="AND" value="1.0">
+                damage/force-aero-lbs GT damage/limits-lift-high
+                crash EQ 0
+            </test>
+
+            <!-- Over-g broken -->
+            <test logic="AND" value="1.0">
+                damage/force-aero-lbs GT damage/limits-lift-medium
+                damage/roll-moment LT -4000.0
+                wing-damage/left-wing LT 1.0<!-- Change to wing-damage/right-wing LT 1.0? -->
+            </test>
+
+            <!-- Over-g damage -->
+            <test logic="AND" value="0.3">
+                damage/force-aero-lbs GT damage/limits-lift-medium
+                damage/roll-moment LT 4000.0
+                damage/roll-moment GT -4000.0
+                wing-damage/left-wing LT 0.3<!-- Change to wing-damage/right-wing LT 0.3? -->
+            </test>
+
+            <!-- Overspeed damage -->
             <test logic="AND" value="0.3">
                 /velocities/airspeed-kt GT damage/limits-vne-medium
                 damage/roll-moment LT 4000.0
@@ -243,10 +312,26 @@
                 wing-damage/right-wing EQ 0.0<!-- Change to wing-damage/right-wing LT 0.3? -->
             </test>
 
+            <!-- Overspeed damage -->
             <test logic="AND" value="0.12">
-                /velocities/airspeed-kt GT /limits/vne
+                /velocities/airspeed-kt GT damage/limits-vne-low
                 damage/roll-moment LT -4000.0
                 wing-damage/left-wing EQ 0.0<!-- Change to wing-damage/right-wing LT 0.12? -->
+            </test>
+
+            <!-- Over-g damage -->
+            <test logic="AND" value="0.12">
+                damage/force-aero-lbs GT damage/limits-lift-medium
+                damage/roll-moment LT 4000.0
+                damage/roll-moment GT -4000.0
+                wing-damage/left-wing EQ 0.0<!-- Change to wing-damage/right-wing EQ 0.0? -->
+            </test>
+
+            <!-- Over-g damage -->
+            <test logic="AND" value="0.12">
+                damage/force-aero-lbs GT damage/limits-lift-low
+                damage/roll-moment LT -4000.0
+                wing-damage/left-wing EQ 0.0<!-- Change to wing-damage/right-wing EQ 0.0? -->
             </test>
         </switch>
 

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -393,22 +393,19 @@
                 contact/unit[17]/compression-ft GT 0.95
                 gear/unit[19]/compression-ft GT 0.95
                 gear/unit[21]/compression-ft GT 0.95
+                pontoon-damage/left-pontoon EQ 1
             </test>
 
             <!-- ================================================================== -->
             <!-- Damaged                                                            -->
             <!-- ================================================================== -->
 
-            <test logic="AND" value="pontoon-damage/left-pontoon">
-                pontoon-damage/left-pontoon NE 1
-
-                <test logic="OR" value="2">
-                    contact/unit[13]/compression-ft GT 0.75
-                    contact/unit[15]/compression-ft GT 0.75
-                    contact/unit[17]/compression-ft GT 0.75
-                    gear/unit[19]/compression-ft GT 0.75
-                    gear/unit[21]/compression-ft GT 0.75
-                </test>
+            <test logic="OR" value="2">
+                contact/unit[13]/compression-ft GT 0.75
+                contact/unit[15]/compression-ft GT 0.75
+                contact/unit[17]/compression-ft GT 0.75
+                gear/unit[19]/compression-ft GT 0.75
+                gear/unit[21]/compression-ft GT 0.75
             </test>
         </switch>
 
@@ -438,22 +435,19 @@
                 contact/unit[18]/compression-ft GT 0.95
                 gear/unit[20]/compression-ft GT 0.95
                 gear/unit[22]/compression-ft GT 0.95
+                pontoon-damage/right-pontoon EQ 1
             </test>
 
             <!-- ================================================================== -->
             <!-- Damaged                                                            -->
             <!-- ================================================================== -->
 
-            <test logic="AND" value="pontoon-damage/right-pontoon">
-                pontoon-damage/right-pontoon NE 1
-
-                <test logic="OR" value="2">
-                    contact/unit[14]/compression-ft GT 0.75
-                    contact/unit[16]/compression-ft GT 0.75
-                    contact/unit[18]/compression-ft GT 0.75
-                    gear/unit[20]/compression-ft GT 0.75
-                    gear/unit[22]/compression-ft GT 0.75
-                </test>
+            <test logic="OR" value="2">
+                contact/unit[14]/compression-ft GT 0.75
+                contact/unit[16]/compression-ft GT 0.75
+                contact/unit[18]/compression-ft GT 0.75
+                gear/unit[20]/compression-ft GT 0.75
+                gear/unit[22]/compression-ft GT 0.75
             </test>
         </switch>
 

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -125,4 +125,20 @@
 
     </channel>
 
+    <channel name="wing-damage">
+
+        <!-- Roll moment due to (diedra + roll rate + yaw rate + ailerons) -->
+        <fcs_function name="damage/roll-moment">
+            <function>
+                <sum>
+                    <property>aero/coefficient/Clb</property>
+                    <property>aero/coefficient/Clp</property>
+                    <property>aero/coefficient/Clr</property>
+                    <property>aero/coefficient/ClDa</property>
+                </sum>
+            </function>
+        </fcs_function>
+
+    </channel>
+
 </system>

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright (c) 2015 onox
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<system name="c172p damage">
+
+    <channel name="gear-forces">
+
+        <!--
+            Numbers MUST be the same coefficients as spring_coeff and
+            damping_coeff in the FDM for nose and main gear!
+        -->
+
+        <fcs_function name="damage/force-nose-gear">
+            <function>
+                <sum>
+                    <product>
+                        <value>1800</value><!-- spring coefficient -->
+                        <property>gear/unit[0]/compression-ft</property>
+                    </product>
+                    <product>
+                        <value>600</value><!-- damping coefficient -->
+                        <property>gear/unit[0]/compression-velocity-fps</property>
+                    </product>
+                </sum>
+            </function>
+        </fcs_function>
+
+        <fcs_function name="damage/force-left-gear">
+            <function>
+                <sum>
+                    <product>
+                        <value>5400</value><!-- spring coefficient -->
+                        <property>gear/unit[1]/compression-ft</property>
+                    </product>
+                    <product>
+                        <value>400</value><!-- damping coefficient -->
+                        <property>gear/unit[1]/compression-velocity-fps</property>
+                    </product>
+                </sum>
+            </function>
+        </fcs_function>
+
+        <fcs_function name="damage/force-right-gear">
+            <function>
+                <sum>
+                    <product>
+                        <value>5400</value><!-- spring coefficient -->
+                        <property>gear/unit[2]/compression-ft</property>
+                    </product>
+                    <product>
+                        <value>400</value><!-- damping coefficient -->
+                        <property>gear/unit[2]/compression-velocity-fps</property>
+                    </product>
+                </sum>
+            </function>
+        </fcs_function>
+
+        <switch>
+            <output>gear/unit[0]/broken</output>
+            <default value="0"/>
+
+            <test logic="AND" value="1">
+                damage/force-nose-gear GT 1400.0
+                settings/damage eq 1
+                damage/repairing EQ 0
+                simulation/sim-time-sec GT 0.25
+            </test>
+
+            <!-- Keep nose gear broken once it breaks -->
+            <test logic="AND" value="1">
+                gear/unit[0]/broken EQ 1
+            </test>
+        </switch>
+
+        <switch>
+            <output>gear/unit[1]/broken</output>
+            <default value="0"/>
+
+            <test logic="AND" value="1">
+                damage/force-left-gear GT 2000.0
+                forces/fby-gear-lbs GT 1500.0
+                settings/damage EQ 1
+                damage/repairing EQ 0
+                simulation/sim-time-sec GT 0.25
+            </test>
+
+            <!-- Keep left gear broken once it breaks -->
+            <test logic="AND" value="1">
+                gear/unit[1]/broken EQ 1
+            </test>
+        </switch>
+
+        <switch>
+            <output>gear/unit[2]/broken</output>
+            <default value="0"/>
+
+            <test logic="AND" value="1">
+                damage/force-right-gear GT 2000.0
+                forces/fby-gear-lbs LT -1500.0
+                settings/damage EQ 1
+                damage/repairing EQ 0
+                simulation/sim-time-sec GT 0.25
+            </test>
+
+            <!-- Keep right gear broken once it breaks -->
+            <test logic="AND" value="1">
+                gear/unit[2]/broken EQ 1
+            </test>
+        </switch>
+
+    </channel>
+
+</system>

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -75,7 +75,8 @@
             <default value="0"/>
 
             <test logic="AND" value="1">
-                damage/force-nose-gear GT 1400.0
+                damage/force-nose-gear GT 2400.0
+                gear/unit[0]/compression-ft GT 0.5
                 settings/damage eq 1
                 damage/repairing EQ 0
                 simulation/sim-time-sec GT 0.25
@@ -92,8 +93,17 @@
             <default value="0"/>
 
             <test logic="AND" value="1">
-                damage/force-left-gear GT 2000.0
+                damage/force-left-gear GT 6500.0
+                gear/unit[1]/compression-ft GT 0.8
+                settings/damage EQ 1
+                damage/repairing EQ 0
+                simulation/sim-time-sec GT 0.25
+            </test>
+
+            <!-- Side force on left gear -->
+            <test logic="AND" value="1">
                 forces/fby-gear-lbs GT 1500.0
+                gear/unit[1]/compression-ft GT 0.23
                 settings/damage EQ 1
                 damage/repairing EQ 0
                 simulation/sim-time-sec GT 0.25
@@ -110,8 +120,17 @@
             <default value="0"/>
 
             <test logic="AND" value="1">
-                damage/force-right-gear GT 2000.0
+                damage/force-right-gear GT 6500.0
+                gear/unit[2]/compression-ft GT 0.8
+                settings/damage EQ 1
+                damage/repairing EQ 0
+                simulation/sim-time-sec GT 0.25
+            </test>
+
+            <!-- Side force on right gear -->
+            <test logic="AND" value="1">
                 forces/fby-gear-lbs LT -1500.0
+                gear/unit[2]/compression-ft GT 0.23
                 settings/damage EQ 1
                 damage/repairing EQ 0
                 simulation/sim-time-sec GT 0.25

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -21,6 +21,11 @@
     <channel name="gear-forces">
 
         <!--
+             References:
+                [1] https://www.youtube.com/watch?v=O1yWkbJuqkE#t=420
+        -->
+
+        <!--
             Numbers MUST be the same coefficients as spring_coeff and
             damping_coeff in the FDM for nose and main gear!
         -->
@@ -75,8 +80,8 @@
             <default value="0"/>
 
             <test logic="AND" value="1">
-                damage/force-nose-gear GT 2400.0
-                gear/unit[0]/compression-ft GT 0.5
+                damage/force-nose-gear GT 1500.0
+                gear/unit[0]/compression-ft GT 0.3
                 settings/damage eq 1
                 damage/repairing EQ 0
                 simulation/sim-time-sec GT 0.25
@@ -92,6 +97,7 @@
             <output>gear/unit[1]/broken</output>
             <default value="0"/>
 
+            <!-- [1] used to guess required force -->
             <test logic="AND" value="1">
                 damage/force-left-gear GT 6500.0
                 gear/unit[1]/compression-ft GT 0.8
@@ -119,6 +125,7 @@
             <output>gear/unit[2]/broken</output>
             <default value="0"/>
 
+            <!-- [1] used to guess required force -->
             <test logic="AND" value="1">
                 damage/force-right-gear GT 6500.0
                 gear/unit[2]/compression-ft GT 0.8

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -189,6 +189,33 @@
             <gain>-1.0</gain>
         </pure_gain>
 
+        <pure_gain name="damage/force-gear-lbs">
+            <input>forces/fbz-gear-lbs</input>
+            <gain>-1.0</gain>
+        </pure_gain>
+
+        <!-- Wings collapsed -->
+        <switch>
+            <output>crash</output>
+            <default value="crash"/>
+
+            <!-- No damage -->
+            <test logic="OR" value="0.0">
+                settings/damage EQ 0
+                damage/repairing EQ 1
+                simulation/sim-time-sec LT 0.25
+            </test>
+
+            <test logic="AND" value="1.0">
+                contact/unit[6]/WOW EQ 1
+                contact/unit[7]/WOW EQ 1
+                contact/unit[8]/WOW EQ 1
+                damage/force-gear-lbs GT damage/limits-lift-high
+                wing-damage/left-wing LT 1.0
+                wing-damage/right-wing LT 1.0
+            </test>
+        </switch>
+
         <!-- Left wing damage -->
         <switch>
             <output>wing-damage/left-wing</output>
@@ -206,8 +233,9 @@
             <!-- ================================================================== -->
 
             <!-- Break wing when its wing tip hits the ground or an object -->
-            <test logic="AND" value="1.0">
+            <test logic="OR" value="1.0">
                 contact/unit[4]/compression-ft GT 0.005
+                crash EQ 1
             </test>
 
             <!-- Overspeed -->
@@ -293,8 +321,9 @@
             <!-- ================================================================== -->
 
             <!-- Break wing when its wing tip hits the ground or an object -->
-            <test logic="AND" value="1.0">
+            <test logic="OR" value="1.0">
                 contact/unit[5]/compression-ft GT 0.005
+                crash EQ 1
             </test>
 
             <!-- Overspeed -->

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -79,12 +79,16 @@
             <output>gear/unit[0]/broken</output>
             <default value="gear/unit[0]/broken"/>
 
+            <!-- No damage -->
+            <test logic="OR" value="0">
+                settings/damage EQ 0
+                damage/repairing EQ 1
+                simulation/sim-time-sec LT 0.25
+            </test>
+
             <test logic="AND" value="1">
                 damage/force-nose-gear GT 1500.0
                 gear/unit[0]/compression-ft GT 0.3
-                settings/damage eq 1
-                damage/repairing EQ 0
-                simulation/sim-time-sec GT 0.25
             </test>
         </switch>
 
@@ -92,22 +96,23 @@
             <output>gear/unit[1]/broken</output>
             <default value="gear/unit[1]/broken"/>
 
+            <!-- No damage -->
+            <test logic="OR" value="0">
+                settings/damage EQ 0
+                damage/repairing EQ 1
+                simulation/sim-time-sec LT 0.25
+            </test>
+
             <!-- [1] used to guess required force -->
             <test logic="AND" value="1">
                 damage/force-left-gear GT 6500.0
                 gear/unit[1]/compression-ft GT 0.8
-                settings/damage EQ 1
-                damage/repairing EQ 0
-                simulation/sim-time-sec GT 0.25
             </test>
 
             <!-- Side force on left gear -->
             <test logic="AND" value="1">
                 forces/fby-gear-lbs GT 1500.0
                 gear/unit[1]/compression-ft GT 0.23
-                settings/damage EQ 1
-                damage/repairing EQ 0
-                simulation/sim-time-sec GT 0.25
             </test>
         </switch>
 
@@ -115,22 +120,23 @@
             <output>gear/unit[2]/broken</output>
             <default value="gear/unit[2]/broken"/>
 
+            <!-- No damage -->
+            <test logic="OR" value="0">
+                settings/damage EQ 0
+                damage/repairing EQ 1
+                simulation/sim-time-sec LT 0.25
+            </test>
+
             <!-- [1] used to guess required force -->
             <test logic="AND" value="1">
                 damage/force-right-gear GT 6500.0
                 gear/unit[2]/compression-ft GT 0.8
-                settings/damage EQ 1
-                damage/repairing EQ 0
-                simulation/sim-time-sec GT 0.25
             </test>
 
             <!-- Side force on right gear -->
             <test logic="AND" value="1">
                 forces/fby-gear-lbs LT -1500.0
                 gear/unit[2]/compression-ft GT 0.23
-                settings/damage EQ 1
-                damage/repairing EQ 0
-                simulation/sim-time-sec GT 0.25
             </test>
         </switch>
 
@@ -188,74 +194,85 @@
             <output>wing-damage/left-wing</output>
             <default value="wing-damage/left-wing"/>
 
+            <!-- No damage -->
+            <test logic="OR" value="0.0">
+                settings/damage EQ 0
+                damage/repairing EQ 1
+                simulation/sim-time-sec LT 0.25
+            </test>
+
+            <!-- ================================================================== -->
+            <!-- Broken                                                             -->
+            <!-- ================================================================== -->
+
             <!-- Break wing when its wing tip hits the ground or an object -->
             <test logic="AND" value="1.0">
                 contact/unit[4]/compression-ft GT 0.005
             </test>
 
-            <!-- Overspeed broken -->
+            <!-- Overspeed -->
             <test logic="AND" value="1.0">
                 /velocities/airspeed-kt GT damage/limits-vne-high
-                crash EQ 0
-                wing-damage/left-wing LT 1.0
             </test>
-
-            <!-- Overspeed broken -->
             <test logic="AND" value="1.0">
                 /velocities/airspeed-kt GT damage/limits-vne-medium
                 damage/roll-moment GT 4000.0
-                wing-damage/right-wing LT 0.5<!-- Change to wing-damage/left-wing LT 0.5? -->
+                wing-damage/right-wing GT 0.0
             </test>
 
-            <!-- Over-g broken -->
+            <!-- Over-g -->
             <test logic="AND" value="1.0">
                 damage/force-aero-lbs GT damage/limits-lift-high
-                crash EQ 0
             </test>
-
-            <!-- Over-g broken -->
             <test logic="AND" value="1.0">
                 damage/force-aero-lbs GT damage/limits-lift-medium
                 damage/roll-moment GT 4000.0
-                wing-damage/right-wing LT 1.0<!-- Change to wing-damage/left-wing LT 1.0? -->
+                wing-damage/right-wing LT 1.0
+                wing-damage/right-wing GT 0.0
             </test>
 
-            <!-- Over-g damage -->
+            <!-- ================================================================== -->
+            <!-- Heavy damage                                                       -->
+            <!-- ================================================================== -->
+
+            <!-- Over-g -->
             <test logic="AND" value="0.3">
                 damage/force-aero-lbs GT damage/limits-lift-medium
                 damage/roll-moment LT 4000.0
                 damage/roll-moment GT -4000.0
-                wing-damage/right-wing LT 0.3<!-- Change to wing-damage/left-wing LT 0.3? -->
+                wing-damage/left-wing LT 0.3
             </test>
 
-            <!-- Overspeed damage -->
+            <!-- Overspeed -->
             <test logic="AND" value="0.3">
                 /velocities/airspeed-kt GT damage/limits-vne-medium
                 damage/roll-moment LT 4000.0
                 damage/roll-moment GT -4000.0
-                wing-damage/left-wing EQ 0.0<!-- Change to wing-damage/left-wing LT 0.3? -->
+                wing-damage/left-wing LT 0.3
             </test>
 
-            <!-- Overspeed damage -->
+            <!-- ================================================================== -->
+            <!-- Light damage                                                       -->
+            <!-- ================================================================== -->
+
+            <!-- Overspeed -->
             <test logic="AND" value="0.12">
                 /velocities/airspeed-kt GT damage/limits-vne-low
                 damage/roll-moment GT 4000.0
-                wing-damage/right-wing EQ 0.0<!-- Change to wing-damage/left-wing LT 0.12? -->
+                wing-damage/left-wing EQ 0.0
             </test>
 
-            <!-- Over-g damage -->
+            <!-- Over-g -->
             <test logic="AND" value="0.12">
                 damage/force-aero-lbs GT damage/limits-lift-medium
                 damage/roll-moment LT 4000.0
                 damage/roll-moment GT -4000.0
-                wing-damage/right-wing EQ 0.0<!-- Change to wing-damage/left-wing EQ 0.0? -->
+                wing-damage/left-wing EQ 0.0
             </test>
-
-            <!-- Over-g damage -->
             <test logic="AND" value="0.12">
                 damage/force-aero-lbs GT damage/limits-lift-low
                 damage/roll-moment GT 4000.0
-                wing-damage/right-wing EQ 0.0<!-- Change to wing-damage/left-wing EQ 0.0? -->
+                wing-damage/left-wing EQ 0.0
             </test>
         </switch>
 
@@ -264,74 +281,85 @@
             <output>wing-damage/right-wing</output>
             <default value="wing-damage/right-wing"/>
 
+            <!-- No damage -->
+            <test logic="OR" value="0.0">
+                settings/damage EQ 0
+                damage/repairing EQ 1
+                simulation/sim-time-sec LT 0.25
+            </test>
+
+            <!-- ================================================================== -->
+            <!-- Broken                                                             -->
+            <!-- ================================================================== -->
+
             <!-- Break wing when its wing tip hits the ground or an object -->
             <test logic="AND" value="1.0">
                 contact/unit[5]/compression-ft GT 0.005
             </test>
 
-            <!-- Overspeed broken -->
+            <!-- Overspeed -->
             <test logic="AND" value="1.0">
                 /velocities/airspeed-kt GT damage/limits-vne-high
-                crash EQ 0
-                wing-damage/right-wing LT 1.0
             </test>
-
-            <!-- Overspeed broken -->
             <test logic="AND" value="1.0">
                 /velocities/airspeed-kt GT damage/limits-vne-medium
                 damage/roll-moment LT -4000.0
-                wing-damage/left-wing LT 0.5<!-- Change to wing-damage/right-wing LT 0.5? -->
+                wing-damage/left-wing GT 0.0
             </test>
 
-            <!-- Over-g broken -->
+            <!-- Over-g -->
             <test logic="AND" value="1.0">
                 damage/force-aero-lbs GT damage/limits-lift-high
-                crash EQ 0
             </test>
-
-            <!-- Over-g broken -->
             <test logic="AND" value="1.0">
                 damage/force-aero-lbs GT damage/limits-lift-medium
                 damage/roll-moment LT -4000.0
-                wing-damage/left-wing LT 1.0<!-- Change to wing-damage/right-wing LT 1.0? -->
+                wing-damage/left-wing LT 1.0
+                wing-damage/left-wing GT 0.0
             </test>
 
-            <!-- Over-g damage -->
+            <!-- ================================================================== -->
+            <!-- Heavy damage                                                       -->
+            <!-- ================================================================== -->
+
+            <!-- Over-g -->
             <test logic="AND" value="0.3">
                 damage/force-aero-lbs GT damage/limits-lift-medium
                 damage/roll-moment LT 4000.0
                 damage/roll-moment GT -4000.0
-                wing-damage/left-wing LT 0.3<!-- Change to wing-damage/right-wing LT 0.3? -->
+                wing-damage/right-wing LT 0.3
             </test>
 
-            <!-- Overspeed damage -->
+            <!-- Overspeed -->
             <test logic="AND" value="0.3">
                 /velocities/airspeed-kt GT damage/limits-vne-medium
                 damage/roll-moment LT 4000.0
                 damage/roll-moment GT -4000.0
-                wing-damage/right-wing EQ 0.0<!-- Change to wing-damage/right-wing LT 0.3? -->
+                wing-damage/right-wing LT 0.3
             </test>
 
-            <!-- Overspeed damage -->
+            <!-- ================================================================== -->
+            <!-- Light damage                                                       -->
+            <!-- ================================================================== -->
+
+            <!-- Overspeed -->
             <test logic="AND" value="0.12">
                 /velocities/airspeed-kt GT damage/limits-vne-low
                 damage/roll-moment LT -4000.0
-                wing-damage/left-wing EQ 0.0<!-- Change to wing-damage/right-wing LT 0.12? -->
+                wing-damage/right-wing EQ 0.0
             </test>
 
-            <!-- Over-g damage -->
+            <!-- Over-g -->
             <test logic="AND" value="0.12">
                 damage/force-aero-lbs GT damage/limits-lift-medium
                 damage/roll-moment LT 4000.0
                 damage/roll-moment GT -4000.0
-                wing-damage/left-wing EQ 0.0<!-- Change to wing-damage/right-wing EQ 0.0? -->
+                wing-damage/right-wing EQ 0.0
             </test>
-
-            <!-- Over-g damage -->
             <test logic="AND" value="0.12">
                 damage/force-aero-lbs GT damage/limits-lift-low
                 damage/roll-moment LT -4000.0
-                wing-damage/left-wing EQ 0.0<!-- Change to wing-damage/right-wing EQ 0.0? -->
+                wing-damage/right-wing EQ 0.0
             </test>
         </switch>
 

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -170,18 +170,18 @@
             <gain>1.0</gain>
         </pure_gain>
 
-        <!-- Limits for over-g damage -->
+        <!-- Limits for over-g damage, lift-force driven -->
         <pure_gain name="damage/limits-lift-high">
-            <input>/limits/max-lift-force</input>
-            <gain>1.5</gain>
+            <input>/fdm/jsbsim/inertia/weight-lbs</input>
+            <gain>5.7</gain> <!-- 3.8 g's x 1.5 -->
         </pure_gain>
         <pure_gain name="damage/limits-lift-medium">
-            <input>/limits/max-lift-force</input>
-            <gain>1.25</gain>
+            <input>/fdm/jsbsim/inertia/weight-lbs</input>
+            <gain>4.75</gain> <!-- 3.8 g's x 1.25 -->
         </pure_gain>
         <pure_gain name="damage/limits-lift-low">
-            <input>/limits/max-lift-force</input>
-            <gain>1.0</gain>
+            <input>/fdm/jsbsim/inertia/weight-lbs</input>
+            <gain>3.8</gain> <!-- 3.8 g's -->
         </pure_gain>
 
         <pure_gain name="damage/force-aero-lbs">

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -75,7 +75,7 @@
             </function>
         </fcs_function>
 
-        <switch>
+        <switch name="nose-gear-broken">
             <output>gear/unit[0]/broken</output>
             <default value="gear/unit[0]/broken"/>
 
@@ -92,7 +92,7 @@
             </test>
         </switch>
 
-        <switch>
+        <switch name="left-gear-broken">
             <output>gear/unit[1]/broken</output>
             <default value="gear/unit[1]/broken"/>
 
@@ -116,7 +116,7 @@
             </test>
         </switch>
 
-        <switch>
+        <switch name="right-gear-broken">
             <output>gear/unit[2]/broken</output>
             <default value="gear/unit[2]/broken"/>
 
@@ -195,7 +195,7 @@
         </pure_gain>
 
         <!-- Wings collapsed -->
-        <switch>
+        <switch name="wings-collapsed">
             <output>crash</output>
             <default value="crash"/>
 
@@ -217,7 +217,7 @@
         </switch>
 
         <!-- Left wing damage -->
-        <switch>
+        <switch name="left-wing-damage">
             <output>wing-damage/left-wing</output>
             <default value="wing-damage/left-wing"/>
 
@@ -305,7 +305,7 @@
         </switch>
 
         <!-- Right wing damage -->
-        <switch>
+        <switch name="right-wing-damage">
             <output>wing-damage/right-wing</output>
             <default value="wing-damage/right-wing"/>
 
@@ -397,7 +397,7 @@
     <channel name="pontoon-damage">
 
         <!-- Left pontoon damage -->
-        <switch>
+        <switch name="left-pontoon-damage">
             <output>pontoon-damage/left-pontoon</output>
             <default value="pontoon-damage/left-pontoon"/>
 
@@ -439,7 +439,7 @@
         </switch>
 
         <!-- Right pontoon damage -->
-        <switch>
+        <switch name="right-pontoon-damage">
             <output>pontoon-damage/right-pontoon</output>
             <default value="pontoon-damage/right-pontoon"/>
 

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -173,11 +173,11 @@
         <!-- Limits for over-g damage -->
         <pure_gain name="damage/limits-lift-high">
             <input>/limits/max-lift-force</input>
-            <gain>1.75</gain>
+            <gain>1.5</gain>
         </pure_gain>
         <pure_gain name="damage/limits-lift-medium">
             <input>/limits/max-lift-force</input>
-            <gain>1.4</gain>
+            <gain>1.25</gain>
         </pure_gain>
         <pure_gain name="damage/limits-lift-low">
             <input>/limits/max-lift-force</input>

--- a/Systems/c172p-ground-effects.xml
+++ b/Systems/c172p-ground-effects.xml
@@ -37,14 +37,12 @@
             <property>/fdm/jsbsim/contact/unit[4]/WOW</property>
             <property>/velocities/groundspeed-kt</property>
             <not>
-                <property>/fdm/jsbsim/wing-both/broken</property>
-            </not>
-            <not>
                 <property>/fdm/jsbsim/contact/unit[4]/broken</property>
             </not>
-            <not>
+            <eq>
                 <property>/fdm/jsbsim/wing-damage/left-wing</property>
-            </not>
+                <value>0.0</value>
+            </eq>
         </product>
     </function>
   </fcs_function>
@@ -55,14 +53,12 @@
             <property>/fdm/jsbsim/contact/unit[5]/WOW</property>
             <property>/velocities/groundspeed-kt</property>
             <not>
-                <property>/fdm/jsbsim/wing-both/broken</property>
-            </not>
-            <not>
                 <property>/fdm/jsbsim/contact/unit[5]/broken</property>
             </not>
-            <not>
+            <eq>
                 <property>/fdm/jsbsim/wing-damage/right-wing</property>
-            </not>
+                <value>0.0</value>
+            </eq>
         </product>
     </function>
   </fcs_function>

--- a/Systems/c172p-ground-effects.xml
+++ b/Systems/c172p-ground-effects.xml
@@ -36,9 +36,6 @@
         <product>	
             <property>/fdm/jsbsim/contact/unit[4]/WOW</property>
             <property>/velocities/groundspeed-kt</property>
-            <not>
-                <property>/fdm/jsbsim/contact/unit[4]/broken</property>
-            </not>
             <eq>
                 <property>/fdm/jsbsim/wing-damage/left-wing</property>
                 <value>0.0</value>
@@ -52,9 +49,6 @@
         <product>
             <property>/fdm/jsbsim/contact/unit[5]/WOW</property>
             <property>/velocities/groundspeed-kt</property>
-            <not>
-                <property>/fdm/jsbsim/contact/unit[5]/broken</property>
-            </not>
             <eq>
                 <property>/fdm/jsbsim/wing-damage/right-wing</property>
                 <value>0.0</value>

--- a/Systems/damage.xml
+++ b/Systems/damage.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright (c) 2015 onox
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<PropertyList>
+
+    <filter>
+        <name>Damage Left Wing Type</name>
+        <type>gain</type>
+
+        <!-- Damaged -->
+        <input>
+            <condition>
+                <and>
+                    <greater-than>
+                        <property>/fdm/jsbsim/wing-damage/left-wing</property>
+                        <value>0.0</value>
+                    </greater-than>
+                    <less-than>
+                        <property>/fdm/jsbsim/wing-damage/left-wing</property>
+                        <value>1.0</value>
+                    </less-than>
+                </and>
+            </condition>
+            <value>2</value>
+        </input>
+
+        <!-- Broken -->
+        <input>
+            <condition>
+                <equals>
+                    <property>/fdm/jsbsim/wing-damage/left-wing</property>
+                    <value>1.0</value>
+                </equals>
+            </condition>
+            <value>1</value>
+        </input>
+
+        <!-- Normal -->
+        <input>
+            <value>0</value>
+        </input>
+
+        <output>
+            <property>/sim/model/c172p/damage/left-wing</property>
+        </output>
+    </filter>
+
+    <filter>
+        <name>Damage Right Wing Type</name>
+        <type>gain</type>
+
+        <!-- Damaged -->
+        <input>
+            <condition>
+                <and>
+                    <greater-than>
+                        <property>/fdm/jsbsim/wing-damage/right-wing</property>
+                        <value>0.0</value>
+                    </greater-than>
+                    <less-than>
+                        <property>/fdm/jsbsim/wing-damage/right-wing</property>
+                        <value>1.0</value>
+                    </less-than>
+                </and>
+            </condition>
+            <value>2</value>
+        </input>
+
+        <!-- Broken -->
+        <input>
+            <condition>
+                <equals>
+                    <property>/fdm/jsbsim/wing-damage/right-wing</property>
+                    <value>1.0</value>
+                </equals>
+            </condition>
+            <value>1</value>
+        </input>
+
+        <!-- Normal -->
+        <input>
+            <value>0</value>
+        </input>
+
+        <output>
+            <property>/sim/model/c172p/damage/right-wing</property>
+        </output>
+    </filter>
+
+</PropertyList>

--- a/Systems/damage.xml
+++ b/Systems/damage.xml
@@ -23,21 +23,15 @@
         <name>Damage Left Wing Type</name>
         <type>gain</type>
 
-        <!-- Damaged -->
+        <!-- Normal -->
         <input>
             <condition>
-                <and>
-                    <greater-than>
-                        <property>/fdm/jsbsim/wing-damage/left-wing</property>
-                        <value>0.0</value>
-                    </greater-than>
-                    <less-than>
-                        <property>/fdm/jsbsim/wing-damage/left-wing</property>
-                        <value>1.0</value>
-                    </less-than>
-                </and>
+                <equals>
+                    <property>/fdm/jsbsim/wing-damage/left-wing</property>
+                    <value>0.0</value>
+                </equals>
             </condition>
-            <value>2</value>
+            <value>0</value>
         </input>
 
         <!-- Broken -->
@@ -51,9 +45,9 @@
             <value>1</value>
         </input>
 
-        <!-- Normal -->
+        <!-- Damaged -->
         <input>
-            <value>0</value>
+            <value>2</value>
         </input>
 
         <output>
@@ -65,21 +59,15 @@
         <name>Damage Right Wing Type</name>
         <type>gain</type>
 
-        <!-- Damaged -->
+        <!-- Normal -->
         <input>
             <condition>
-                <and>
-                    <greater-than>
-                        <property>/fdm/jsbsim/wing-damage/right-wing</property>
-                        <value>0.0</value>
-                    </greater-than>
-                    <less-than>
-                        <property>/fdm/jsbsim/wing-damage/right-wing</property>
-                        <value>1.0</value>
-                    </less-than>
-                </and>
+                <equals>
+                    <property>/fdm/jsbsim/wing-damage/right-wing</property>
+                    <value>0.0</value>
+                </equals>
             </condition>
-            <value>2</value>
+            <value>0</value>
         </input>
 
         <!-- Broken -->
@@ -93,9 +81,9 @@
             <value>1</value>
         </input>
 
-        <!-- Normal -->
+        <!-- Damaged -->
         <input>
-            <value>0</value>
+            <value>2</value>
         </input>
 
         <output>

--- a/Systems/flight-recorder/components/damage.xml
+++ b/Systems/flight-recorder/components/damage.xml
@@ -35,20 +35,12 @@
         <property type="string">/fdm/jsbsim/crash</property>
     </signal>
     <signal>
-        <type>bool</type>
-        <property type="string">/fdm/jsbsim/left-pontoon/damaged</property>
+        <type>int8</type>
+        <property type="string">/fdm/jsbsim/pontoon-damage/left-pontoon</property>
     </signal>
     <signal>
-        <type>bool</type>
-        <property type="string">/fdm/jsbsim/left-pontoon/broken</property>
-    </signal>
-    <signal>
-        <type>bool</type>
-        <property type="string">/fdm/jsbsim/right-pontoon/damaged</property>
-    </signal>
-    <signal>
-        <type>bool</type>
-        <property type="string">/fdm/jsbsim/right-pontoon/broken</property>
+        <type>int8</type>
+        <property type="string">/fdm/jsbsim/pontoon-damage/right-pontoon</property>
     </signal>
     <signal>
         <type>int8</type>

--- a/Systems/flight-recorder/components/damage.xml
+++ b/Systems/flight-recorder/components/damage.xml
@@ -15,14 +15,6 @@
         <property type="string">/fdm/jsbsim/gear/unit[2]/broken</property>
     </signal>
     <signal>
-        <type>bool</type>
-        <property type="string">/fdm/jsbsim/contact/unit[4]/broken</property>
-    </signal>
-    <signal>
-        <type>bool</type>
-        <property type="string">/fdm/jsbsim/contact/unit[5]/broken</property>
-    </signal>
-    <signal>
         <type>float</type>
         <property type="string">/fdm/jsbsim/contact/unit[4]/z-position</property>
     </signal>
@@ -59,7 +51,7 @@
         <property type="string">/fdm/jsbsim/right-pontoon/broken</property>
     </signal>
     <signal>
-        <type>int</type>
+        <type>int8</type>
         <property type="string">/fdm/jsbsim/bushkit</property>
     </signal>
 

--- a/Systems/flight-recorder/components/damage.xml
+++ b/Systems/flight-recorder/components/damage.xml
@@ -39,10 +39,6 @@
         <property type="string">/fdm/jsbsim/wing-damage/right-wing</property>
     </signal>
     <signal>
-        <type>float</type>
-        <property type="string">/fdm/jsbsim/wing-both/broken</property>
-    </signal>
-    <signal>
         <type>bool</type>
         <property type="string">/fdm/jsbsim/crash</property>
     </signal>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -138,6 +138,12 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <taxi type="bool">false</taxi>
         <landing type="bool">false</landing>
       </lighting>
+
+      <!-- Damage type (0 = normal, 1 = broken, 2 = damaged) used by model -->
+      <damage>
+        <left-wing type="int">0</left-wing>
+        <right-wing type="int">0</right-wing>
+      </damage>
     </c172p>
     <hide-yoke type="bool">false</hide-yoke>
     
@@ -294,8 +300,8 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <!-- 15 unused -->
         <!-- 16 unused -->
 		<int n="17" alias="/engines/active-engine/exhaust"/>
-        <int n="18" alias="/fdm/jsbsim/wing-damage/left-wing"/>
-		<int n="19" alias="/fdm/jsbsim/wing-damage/right-wing"/>
+        <int n="18" alias="/sim/model/c172p/damage/left-wing"/>
+		<int n="19" alias="/sim/model/c172p/damage/right-wing"/>
 
         <!-- Registration number over MP -->
         <string n="0" alias="/sim/model/immat"/>
@@ -674,8 +680,8 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 		<weather type="bool">0</weather>
 		<bushkit type="int">0</bushkit>
 		<wing-damage>
-            <left-wing type="int">0</left-wing>
-            <right-wing type="int">0</right-wing>
+            <left-wing type="double">0.0</left-wing>
+            <right-wing type="double">0.0</right-wing>
         </wing-damage>
 		<left-pontoon>
 			<damaged type="bool">0</damaged>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -296,10 +296,10 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <int n="7" alias="/fdm/jsbsim/gear/unit[1]/broken"/>
         <int n="8" alias="/fdm/jsbsim/gear/unit[2]/broken"/>
         <int n="9" alias="/fdm/jsbsim/bushkit"/>
-        <int n="10" alias="/fdm/jsbsim/left-pontoon/damaged"/>
-        <int n="11" alias="/fdm/jsbsim/left-pontoon/broken"/>
-        <int n="12" alias="/fdm/jsbsim/right-pontoon/damaged"/>
-        <int n="13" alias="/fdm/jsbsim/right-pontoon/broken"/>
+        <int n="10" alias="/fdm/jsbsim/pontoon-damage/left-pontoon"/>
+        <int n="11" alias="/fdm/jsbsim/pontoon-damage/right-pontoon"/>
+        <!-- 12 unused -->
+        <!-- 13 unused -->
         <int n="14" alias="/fdm/jsbsim/crash"/>
         <!-- 15 unused -->
         <!-- 16 unused -->
@@ -686,14 +686,10 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <left-wing type="double">0.0</left-wing>
             <right-wing type="double">0.0</right-wing>
         </wing-damage>
-		<left-pontoon>
-			<damaged type="bool">0</damaged>
-			<broken type="bool">0</broken>
-		</left-pontoon>
-		<right-pontoon>
-			<damaged type="bool">0</damaged>
-			<broken type="bool">0</broken>
-		</right-pontoon>
+        <pontoon-damage>
+            <left-pontoon type="int">0</left-pontoon>
+            <right-pontoon type="int">0</right-pontoon>
+        </pontoon-damage>
         <damage>
             <repairing type="bool">false</repairing>
         </damage>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -148,7 +148,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
     </crew>
 	
 	<!-- human models persistent menu choice -->
-	<occupants type="bool">0</occupants>
+	<occupants type="bool">false</occupants>
   
     <!-- an exit for the walker -->
     <map>
@@ -264,12 +264,12 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 		<float n="15" alias="/fdm/jsbsim/ground/nose-tyre-smoke-ground-effect-speed-kt-actual"/>
 		<float n="16" alias="/fdm/jsbsim/ground/left-tyre-smoke-ground-effect-speed-kt-actual"/>
 		<float n="17" alias="/fdm/jsbsim/ground/right-tyre-smoke-ground-effect-speed-kt-actual"/>
+		<float n="18" alias="/fdm/jsbsim/wing-damage/left-wing"/>
+		<float n="19" alias="/fdm/jsbsim/wing-damage/right-wing"/>
 
         <int n="1" alias="/sim/model/c172p/lighting/beacon-top/state"/>
         <int n="2" alias="/sim/model/c172p/lighting/strobes/state"/>
         <int n="3" alias="/fdm/jsbsim/crash"/>
-        <int n="4" alias="/fdm/jsbsim/contact/unit[4]/broken"/>
-        <int n="5" alias="/fdm/jsbsim/contact/unit[5]/broken"/>
         <int n="6" alias="/fdm/jsbsim/gear/unit[0]/broken"/>
         <int n="7" alias="/fdm/jsbsim/gear/unit[1]/broken"/>
         <int n="8" alias="/fdm/jsbsim/gear/unit[2]/broken"/>
@@ -278,9 +278,6 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <int n="11" alias="/fdm/jsbsim/left-pontoon/broken"/>
         <int n="12" alias="/fdm/jsbsim/right-pontoon/damaged"/>
         <int n="13" alias="/fdm/jsbsim/right-pontoon/broken"/>
-		<int n="14" alias="/fdm/jsbsim/wing-both/broken"/>
-		<int n="15" alias="/fdm/jsbsim/wing-damage/left-wing"/>
-		<int n="16" alias="/fdm/jsbsim/wing-damage/right-wing"/>
 		<int n="17" alias="/engines/active-engine/exhaust"/>
 
         <!-- Registration number over MP -->
@@ -663,9 +660,6 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <left-wing type="double">0</left-wing>
             <right-wing type="double">0</right-wing>
         </wing-damage>
-		<wing-both>
-            <broken type="bool">0</broken>
-		</wing-both>
 		<left-pontoon>
 			<damaged type="bool">0</damaged>
 			<broken type="bool">0</broken>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -178,7 +178,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
     <path>/sim/rendering/shadow</path>
     <path>/sim/rendering/shadow-volume</path>
     <path>/sim/model/occupants</path>
-    <path>/fdm/jsbsim/damage</path>
+    <path>/fdm/jsbsim/settings/damage</path>
     <path>/fdm/jsbsim/bushkit</path>
     <path>/controls/engines/active-engine</path>
     <path>/environment/aircraft-effects/cabin-heat-set</path>
@@ -678,7 +678,6 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 			</unit>
 		</contact>
 		<crash type="bool">0</crash>
-		<damage type="bool">0</damage>
 		<running type="bool">0</running>
 		<complex type="bool">0</complex>
 		<weather type="bool">0</weather>
@@ -695,6 +694,12 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 			<damaged type="bool">0</damaged>
 			<broken type="bool">0</broken>
 		</right-pontoon>
+        <damage>
+            <repairing type="bool">false</repairing>
+        </damage>
+        <settings>
+		    <damage type="bool">false</damage>
+        </settings>
     </jsbsim>
   </fdm>
   <!-- End Damage Mod -->

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -240,6 +240,10 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
     <property-rule n="103">
       <path>Aircraft/c172p/Systems/engine.xml</path>
     </property-rule>
+
+    <property-rule n="104">
+      <path>Aircraft/c172p/Systems/damage.xml</path>
+    </property-rule>
   </systems>
 
   <sound>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -279,7 +279,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <!-- 0 unused -->
         <int n="1" alias="/sim/model/c172p/lighting/beacon-top/state"/>
         <int n="2" alias="/sim/model/c172p/lighting/strobes/state"/>
-        <int n="3" alias="/fdm/jsbsim/crash"/>
+        <!-- 3 unused -->
         <int n="4" alias="/sim/model/c172p/lighting/taxi"/>
         <int n="5" alias="/sim/model/c172p/lighting/landing"/>
         <int n="6" alias="/fdm/jsbsim/gear/unit[0]/broken"/>
@@ -290,7 +290,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <int n="11" alias="/fdm/jsbsim/left-pontoon/broken"/>
         <int n="12" alias="/fdm/jsbsim/right-pontoon/damaged"/>
         <int n="13" alias="/fdm/jsbsim/right-pontoon/broken"/>
-        <!-- 14 unused -->
+        <int n="14" alias="/fdm/jsbsim/crash"/>
         <!-- 15 unused -->
         <!-- 16 unused -->
 		<int n="17" alias="/engines/active-engine/exhaust"/>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -546,7 +546,22 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
   </weight>
  </payload>
 
- <limits>
+    <limits>
+        <!--
+            Specifications Vne: 158 KIAS
+            Normal category (1500 - 2400 or 2550 lbs):
+                max positive-g: 3.8, max negative-g: -1.52,
+            Utility category (1500 - 2100 lbs):
+                max positive-g: 4.4, max negative-g: -1.76,
+            Structure holds at least 150 % max g's
+        -->
+        <max-positive-g>3.8</max-positive-g>
+        <max-negative-g>-1.52</max-negative-g>
+        <vne>158</vne>
+
+        <!-- 2550*3.8 -->
+        <max-lift-force>9690</max-lift-force>
+
   <mass-and-balance-160hp>
     <maximum-ramp-mass-lbs>2407</maximum-ramp-mass-lbs>
     <maximum-takeoff-mass-lbs>2400</maximum-takeoff-mass-lbs>
@@ -643,6 +658,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 		<running type="bool">0</running>
 		<complex type="bool">0</complex>
 		<weather type="bool">0</weather>
+		<bushkit type="int">0</bushkit>
 		<wing-damage>
             <left-wing type="double">0</left-wing>
             <right-wing type="double">0</right-wing>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -91,6 +91,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
     </liveryfloat>
 
     <c172p>
+      <!-- Registration number -->
       <regnum1 type="int">0</regnum1>
       <regnum2 type="int">0</regnum2>
       <regnum3 type="int">0</regnum3>
@@ -101,6 +102,8 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
       <fairing1 type="bool">true</fairing1>
       <fairing2 type="bool">false</fairing2>
       <fairing3 type="bool">false</fairing3>
+
+      <!-- Event sounds -->
       <sound>
         <click-light type="bool">false</click-light>
         <click-master type="bool">false</click-master>
@@ -129,6 +132,12 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <click-kx165-1-dial type="bool">false</click-kx165-1-dial>
         <click-kx165-2-dial type="bool">false</click-kx165-2-dial>
       </sound>
+
+      <!-- Lighting used by model and ALS -->
+      <lighting>
+        <taxi type="bool">false</taxi>
+        <landing type="bool">false</landing>
+      </lighting>
     </c172p>
     <hide-yoke type="bool">false</hide-yoke>
     
@@ -250,8 +259,8 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <float n="1" alias="/sim/model/door-positions/leftDoor/position-norm"/>
         <float n="2" alias="/sim/model/door-positions/baggageDoor/position-norm"/>
 		<float n="3" alias="/systems/electrical/outputs/nav-lights"/>
-        <float n="4" alias="/systems/electrical/outputs/taxi-light"/>
-        <float n="5" alias="/systems/electrical/outputs/landing-lights"/>
+        <!-- 4 unused -->
+        <!-- 5 unused -->
 		<float n="6" alias="/fdm/jsbsim/hydro/spray-wake-speed-kt-actual"/>
 		<float n="7" alias="/fdm/jsbsim/hydro/left-ground-effect-speed-kt-actual"/>
 		<float n="8" alias="/fdm/jsbsim/hydro/right-ground-effect-speed-kt-actual"/>	
@@ -267,9 +276,12 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 		<float n="18" alias="/fdm/jsbsim/wing-damage/left-wing"/>
 		<float n="19" alias="/fdm/jsbsim/wing-damage/right-wing"/>
 
+        <!-- 0 unused -->
         <int n="1" alias="/sim/model/c172p/lighting/beacon-top/state"/>
         <int n="2" alias="/sim/model/c172p/lighting/strobes/state"/>
         <int n="3" alias="/fdm/jsbsim/crash"/>
+        <int n="4" alias="/sim/model/c172p/lighting/taxi"/>
+        <int n="5" alias="/sim/model/c172p/lighting/landing"/>
         <int n="6" alias="/fdm/jsbsim/gear/unit[0]/broken"/>
         <int n="7" alias="/fdm/jsbsim/gear/unit[1]/broken"/>
         <int n="8" alias="/fdm/jsbsim/gear/unit[2]/broken"/>
@@ -278,7 +290,12 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <int n="11" alias="/fdm/jsbsim/left-pontoon/broken"/>
         <int n="12" alias="/fdm/jsbsim/right-pontoon/damaged"/>
         <int n="13" alias="/fdm/jsbsim/right-pontoon/broken"/>
+        <!-- 14 unused -->
+        <!-- 15 unused -->
+        <!-- 16 unused -->
 		<int n="17" alias="/engines/active-engine/exhaust"/>
+        <!-- 18 unused -->
+        <!-- 19 unused -->
 
         <!-- Registration number over MP -->
         <string n="0" alias="/sim/model/immat"/>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -273,8 +273,8 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 		<float n="15" alias="/fdm/jsbsim/ground/nose-tyre-smoke-ground-effect-speed-kt-actual"/>
 		<float n="16" alias="/fdm/jsbsim/ground/left-tyre-smoke-ground-effect-speed-kt-actual"/>
 		<float n="17" alias="/fdm/jsbsim/ground/right-tyre-smoke-ground-effect-speed-kt-actual"/>
-		<float n="18" alias="/fdm/jsbsim/wing-damage/left-wing"/>
-		<float n="19" alias="/fdm/jsbsim/wing-damage/right-wing"/>
+		<!-- 18 unused -->
+        <!-- 19 unused -->
 
         <!-- 0 unused -->
         <int n="1" alias="/sim/model/c172p/lighting/beacon-top/state"/>
@@ -294,8 +294,8 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <!-- 15 unused -->
         <!-- 16 unused -->
 		<int n="17" alias="/engines/active-engine/exhaust"/>
-        <!-- 18 unused -->
-        <!-- 19 unused -->
+        <int n="18" alias="/fdm/jsbsim/wing-damage/left-wing"/>
+		<int n="19" alias="/fdm/jsbsim/wing-damage/right-wing"/>
 
         <!-- Registration number over MP -->
         <string n="0" alias="/sim/model/immat"/>
@@ -674,8 +674,8 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 		<weather type="bool">0</weather>
 		<bushkit type="int">0</bushkit>
 		<wing-damage>
-            <left-wing type="double">0</left-wing>
-            <right-wing type="double">0</right-wing>
+            <left-wing type="int">0</left-wing>
+            <right-wing type="int">0</right-wing>
         </wing-damage>
 		<left-pontoon>
 			<damaged type="bool">0</damaged>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -677,10 +677,10 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 			  <broken type="bool">0</broken>
 			</unit>
 		</contact>
-		<crash type="bool">0</crash>
-		<running type="bool">0</running>
-		<complex type="bool">0</complex>
-		<weather type="bool">0</weather>
+		<crash type="bool">false</crash>
+		<running type="bool">false</running>
+		<complex type="bool">false</complex>
+		<weather type="bool">false</weather>
 		<bushkit type="int">0</bushkit>
 		<wing-damage>
             <left-wing type="double">0.0</left-wing>

--- a/c172p.xml
+++ b/c172p.xml
@@ -768,7 +768,7 @@
             </fcs_function>
 
             <!-- Primer logic for 160 HP engine -->
-            <switch>
+            <switch name="Mixture Position 160 HP">
                 <default value="fcs/mixture-cmd-norm[0]"/>
                 <output>fcs/mixture-pos-norm[0]</output>
 
@@ -782,7 +782,7 @@
             </switch>
 
             <!-- Primer logic for 180 HP engine -->
-            <switch>
+            <switch name="Mixture Position 180 HP">
                 <default value="fcs/mixture-cmd-norm[1]"/>
                 <output>fcs/mixture-pos-norm[1]</output>
 

--- a/c172p.xml
+++ b/c172p.xml
@@ -1645,6 +1645,7 @@
  <system file="hydrodynamics"/>
  <system file="c172p-hydrodynamics"/>
  <system file="c172p-ground-effects"/>
+ <system file="c172p-damage"/>
  <system file="c172p-sounds"/>
 
 <!--

--- a/c172p.xml
+++ b/c172p.xml
@@ -905,7 +905,7 @@
             </product>
         </function> 
 
-		<function name="aero/function/left-wing-damage">
+		<!--<function name="aero/function/left-wing-damage">
             <switch>
                 <property>wing-damage/left-wing</property>
                 <value>0.0</value>
@@ -923,14 +923,14 @@
                 <value>0.12</value>
                 <value>0.3</value>
             </switch>
-        </function>
+        </function>-->
 
 		<function name="aero/function/total-wing-damage">
             <description>Total damage on wings</description>
             <product>
                 <sum>
-                    <property>aero/function/left-wing-damage</property>
-                    <property>aero/function/right-wing-damage</property>
+                    <property>wing-damage/left-wing</property>
+                    <property>wing-damage/right-wing</property>
                 </sum>
                 <value>0.5</value>
             </product>
@@ -1308,7 +1308,7 @@
                     <property>aero/qbar-psf</property>
                     <property>metrics/Sw-sqft</property>
                     <property>metrics/bw-ft</property>
-                    <property>aero/function/left-wing-damage</property>
+                    <property>wing-damage/left-wing</property>
                     <value>-0.3</value>
                 </product>
             </function>
@@ -1318,7 +1318,7 @@
                     <property>aero/qbar-psf</property>
                     <property>metrics/Sw-sqft</property>
                     <property>metrics/bw-ft</property>
-                    <property>aero/function/right-wing-damage</property>
+                    <property>wing-damage/right-wing</property>
                     <value>0.3</value>
                 </product>
             </function>

--- a/c172p.xml
+++ b/c172p.xml
@@ -905,26 +905,6 @@
             </product>
         </function> 
 
-		<!--<function name="aero/function/left-wing-damage">
-            <switch>
-                <property>wing-damage/left-wing</property>
-                <value>0.0</value>
-                <value>1.0</value>
-                <value>0.12</value>
-                <value>0.3</value>
-            </switch>
-        </function>
-
-        <function name="aero/function/right-wing-damage">
-            <switch>
-                <property>wing-damage/right-wing</property>
-                <value>0.0</value>
-                <value>1.0</value>
-                <value>0.12</value>
-                <value>0.3</value>
-            </switch>
-        </function>-->
-
 		<function name="aero/function/total-wing-damage">
             <description>Total damage on wings</description>
             <product>

--- a/c172p.xml
+++ b/c172p.xml
@@ -905,12 +905,32 @@
             </product>
         </function> 
 
+		<function name="aero/function/left-wing-damage">
+            <switch>
+                <property>wing-damage/left-wing</property>
+                <value>0.0</value>
+                <value>1.0</value>
+                <value>0.12</value>
+                <value>0.3</value>
+            </switch>
+        </function>
+
+        <function name="aero/function/right-wing-damage">
+            <switch>
+                <property>wing-damage/right-wing</property>
+                <value>0.0</value>
+                <value>1.0</value>
+                <value>0.12</value>
+                <value>0.3</value>
+            </switch>
+        </function>
+
 		<function name="aero/function/total-wing-damage">
             <description>Total damage on wings</description>
             <product>
                 <sum>
-                    <property>wing-damage/left-wing</property>
-                    <property>wing-damage/right-wing</property>
+                    <property>aero/function/left-wing-damage</property>
+                    <property>aero/function/right-wing-damage</property>
                 </sum>
                 <value>0.5</value>
             </product>
@@ -1288,7 +1308,7 @@
                     <property>aero/qbar-psf</property>
                     <property>metrics/Sw-sqft</property>
                     <property>metrics/bw-ft</property>
-                    <property>wing-damage/left-wing</property>
+                    <property>aero/function/left-wing-damage</property>
                     <value>-0.3</value>
                 </product>
             </function>
@@ -1298,7 +1318,7 @@
                     <property>aero/qbar-psf</property>
                     <property>metrics/Sw-sqft</property>
                     <property>metrics/bw-ft</property>
-                    <property>wing-damage/right-wing</property>
+                    <property>aero/function/right-wing-damage</property>
                     <value>0.3</value>
                 </product>
             </function>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -107,7 +107,7 @@
             <checkbox>
                 <halign>left</halign>
                 <label>Damage</label>
-                <property>/fdm/jsbsim/damage</property>
+                <property>/fdm/jsbsim/settings/damage</property>
                 <live>true</live>
                 <binding>
                     <command>dialog-apply</command>
@@ -121,7 +121,7 @@
                 <pref-height>28</pref-height>
                 <binding>
                     <command>nasal</command>
-                    <script>c172p.resetalldamage();electrical.reset_battery_and_circuit_breakers();c172p.click("engine-repair", 6.0)</script>
+                    <script>c172p.repair_damage();electrical.reset_battery_and_circuit_breakers();c172p.click("engine-repair", 6.0)</script>
                 </binding>
             </button>
         </group>


### PR DESCRIPTION
Fixes #280, #336, #348, and #351. Additionally it:

* has more deterministic execution of damage logic
* fixes a small problem in 88d5db5
* frees up 5 MP properties
* removes the possibility to damage the aircraft when switching to a new bush kit
* the old code in `Nasal/physics.nas` had a problem that you could manage to get `settledelay` greater than 5, causing the code to continuously keep executing `poll_gear_delay()`