### PR TITLE
Remove usage of model-transparent effect in TC to avoid weird colors

### DIFF
--- a/Models/Interior/Panel/Instruments/tc/tc.xml
+++ b/Models/Interior/Panel/Instruments/tc/tc.xml
@@ -3,13 +3,6 @@
 <PropertyList>
 
  <path>tc.ac</path>
-<!-- MOD: Transparent effect -->
-   <effect>
-       <inherits-from>Effects/model-transparent</inherits-from>
-       <object-name>Face</object-name>
-       <object-name>Airplane</object-name>
-   </effect>
- <!-- MODEND: Transparent effect -->
 
  <effect>
   <inherits-from>../../../../Effects/interior/c172p-flashlight</inherits-from>
@@ -30,7 +23,7 @@
    <red>1.0</red>
    <green>0.2</green>
    <blue>0.0</blue>
-   <factor-prop>/sim/model//material/instruments/factor</factor-prop>
+   <factor-prop>/sim/model/material/instruments/factor</factor-prop>
   </emission>
  </animation>
 


### PR DESCRIPTION
Fixes #146 in ALS and Rembrandt.