### PR TITLE
Re-add tooltip to magnetic compass.

### DIFF
--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass.xml
@@ -21,7 +21,8 @@
  </animation>
 
   <animation>
-  <type>material</type>
+  <!-- <type>material</type> set this if you do NOT want a tooltip -->
+  <type>pick</type>
   <object-name>Ring</object-name>
   <emission>
    <red>1.0</red>
@@ -29,5 +30,14 @@
    <blue>0.0</blue>
    <factor-prop>/sim/model//material/instruments/factor</factor-prop>
   </emission>
+  <hovered>
+    <binding>
+        <command>set-tooltip</command>
+        <tooltip-id>magnetcompass</tooltip-id>
+        <label>Magnetic heading: %3d</label>
+        <property>instrumentation/magnetic-compass/indicated-heading-deg</property>
+        <mapping>heading</mapping>
+    </binding>
+   </hovered>
  </animation>
 </PropertyList>


### PR DESCRIPTION
There was discussion in #313 and #316 that seemed to reach the conclusion
that this 'helpful' display is not used. It is...

In fact it should be used on each start-up, and perhaps during flight to
set and keep the gyroscopic compass 'accurate'...

Tried to read through the history of this change...

wkitty42 commented 16 days ago #313
https://github.com/Juanvvc/c172p-detailed/issues/313#issuecomment-113345108

mag-compass - why is it `clickable`? Because we need the tool tip to tell us what it is on!

Yes, you can not change anything - it is a magnetic compass - but without zooming in, and repositioning to read it is difficult to read, as it is in RL ;=))

And some of us fly **without** the hud ;=)))) so need that tooltip. And was very amused that others consider the magnetic compass as an `ornament` LOL!

onox commented 16 days ago # 316
https://github.com/Juanvvc/c172p-detailed/issues/316#issuecomment-113579784

So think this is a move in the wrong direction ;=((

A little off topic, but I also do not exactly know **WHY** all the mag-compass stuff was moved from `Instruments-3d` into the `c172p` folders. 

Yes, I can see maybe wanting to add this 'flashlight', but still why copy the mag-compass.ac, and mag-compass.rgb? These could have continued to live in the `common` folder...

I hope the idea will be to continue to try and **share** common instruments, where possible. That is why `Instruments` and `Instruments-3d` continue to exist in fgdata/Aircraft...

Anyway, this is mainly about restoring the magnetic compass tooltip to show its value to facilitate setting the gyroscopic compass before start, and perhaps re-set the gyro during flight if gyro drift is implemented...

