### PR TITLE
Add strobe condition for  > 0 and < 1

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -4666,6 +4666,10 @@
                     <property alias="/params/wing_left_damaged/property"/>
                     <value>1</value>
                 </not-equals>
+				<greater-than>
+                    <property alias="/params/wing_left_damaged/property"/>
+                    <value>0</value>
+                </greater-than>
                 <not>
                     <property alias="/params/crash/property"/>
                 </not>
@@ -4682,6 +4686,10 @@
                     <property alias="/params/wing_right_damaged/property"/>
                     <value>1</value>
                 </not-equals>
+				<greater-than>
+                    <property alias="/params/wing_right_damaged/property"/>
+                    <value>0</value>
+                </greater-than>
                 <not>
                     <property alias="/params/crash/property"/>
                 </not>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -4662,14 +4662,10 @@
         <condition>
             <and>
                 <property alias="/params/lighting/strobes/property"/>
-                <not-equals>
+				<equals>
                     <property alias="/params/wing_left_damaged/property"/>
-                    <value>1</value>
-                </not-equals>
-				<greater-than>
-                    <property alias="/params/wing_left_damaged/property"/>
-                    <value>0</value>
-                </greater-than>
+                    <value>2</value>
+                </equals>
                 <not>
                     <property alias="/params/crash/property"/>
                 </not>
@@ -4682,14 +4678,10 @@
         <condition>
             <and>
                 <property alias="/params/lighting/strobes/property"/>
-                <not-equals>
+                <equals>
                     <property alias="/params/wing_right_damaged/property"/>
-                    <value>1</value>
-                </not-equals>
-				<greater-than>
-                    <property alias="/params/wing_right_damaged/property"/>
-                    <value>0</value>
-                </greater-than>
+                    <value>2</value>
+                </equals>
                 <not>
                     <property alias="/params/crash/property"/>
                 </not>


### PR DESCRIPTION
@onox, I did this in hurry without a lot of thought .It appears to work but I don't know what all was done with recorder and MP in regards to the refactoring of the damage conditions. I think what happened was a prop for damage was removed and instead the props wing_??_damaged (floats) were incorporated.
But the (< 1 and > 0) for damage was never added to the damage condition.
You may want to write it differently than what i used. Like I said I wasn't really considering everything because I didn't make these changes and don't know what all was done. But I wanted to verify that this condition was all that got broke and I think it was.