### PR TITLE
180 HP controls the throttle of both engine[1] and engine[0] properties

### DIFF
--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -332,7 +332,7 @@
             <property>/controls/engines/current-engine/throttle</property>
         </input>
         <input>
-            <value>0.0</value>
+            <property>/controls/engines/engine[1]/throttle</property>
         </input>
         <output>
             <property>/controls/engines/engine[0]/throttle</property>
@@ -355,7 +355,6 @@
             <value>0.0</value>
         </input>
         <output>
-            <property>/controls/engines/engine[0]/throttle</property>
             <property>/controls/engines/engine[1]/throttle</property>
         </output>
     </filter>

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -355,6 +355,7 @@
             <value>0.0</value>
         </input>
         <output>
+            <property>/controls/engines/engine[0]/throttle</property>
             <property>/controls/engines/engine[1]/throttle</property>
         </output>
     </filter>


### PR DESCRIPTION
I found a fix for the bug #354 , but it's probably not very elegant (though it works!). The thing is that the throttle displayed on the HUD is always from property `/controls/engines/engine[0]/throttle`, but the 180 HP engine currently controls only `/controls/engines/engine[1]/throttle`. If we set it to control the throttles of both `engine[1]` and `engine[0]`, then the HUD display shows the correct throttle position and the engine also behave normally (as changing `engine[0]`'s throttle rightfully does nothing to the 180 HP). 

@onox please feel free to decline this fix if you think it's too much of a hack, okay?