### PR TITLE
co-pilot view, pilot model now depends on weight

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -110,12 +110,14 @@
             var co_pilot = rplayer.initNode("pax/co-pilot/present", 0, "BOOL");
             var left_passenger = rplayer.initNode("pax/left-passenger/present", 0, "BOOL");
             var right_passenger = rplayer.initNode("pax/right-passenger/present", 0, "BOOL");
+            var pilot = rplayer.initNode("pax/pilot/present", 0, "BOOL");
 
             setlistener(pax_state_path, func (node) {
                 var state = node.getValue();
                 co_pilot.setBoolValue(bits.test(state, 0));
                 left_passenger.setBoolValue(bits.test(state, 1));
                 right_passenger.setBoolValue(bits.test(state, 2));
+                pilot.setBoolValue(bits.test(state, 3));
             }, 1, 0);
 
             # Make sure human occupants are always visible in remote aircraft

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -5220,7 +5220,7 @@
         <path>Human/male-copilot.xml</path>
         <offsets>
             <x-m> 0.9 </x-m>
-            <y-m> 0.2 </y-m>
+            <y-m> -0.2 </y-m>
             <z-m> -1.45 </z-m>
         </offsets>
     </model>
@@ -5229,7 +5229,7 @@
         <path>Human/male-copilot.xml</path>
         <offsets>
             <x-m> 0.9 </x-m>
-            <y-m> -0.2 </y-m>
+            <y-m> 0.2 </y-m>
             <z-m> -1.45 </z-m>
         </offsets>
     </model>
@@ -5269,7 +5269,7 @@
         </condition>
     </animation>
 
-    <!-- Co-pilot not visible if not enough weight on his seat or if uing Cockpit Right Seat View-->
+    <!-- Co-pilot not visible if not enough weight on his seat or if using Cockpit Right Seat View-->
     <animation>
         <type>select</type>
         <object-name>Copilot</object-name>
@@ -5285,13 +5285,17 @@
         </condition>
     </animation>
     
-    <!-- Passangers not visible if not enough weight on his seat -->
+    <!-- Passangers not visible if not enough weight on their seats or if using their view -->
     <animation>
         <type>select</type>
         <object-name>LeftPassenger</object-name>
         <condition>
             <and>
-                <property>pax/right-passenger/present</property>
+                <not-equals>
+                    <property>sim/current-view/name</property>
+                    <value>Left Passenger Seat View</value>
+                </not-equals>
+                <property>pax/left-passenger/present</property>
                 <property>sim/model/occupants</property>
             </and>
         </condition>
@@ -5301,7 +5305,11 @@
         <object-name>RightPassenger</object-name>
         <condition>
             <and>
-                <property>pax/left-passenger/present</property>
+                <not-equals>
+                    <property>sim/current-view/name</property>
+                    <value>Right Passenger Seat View</value>
+                </not-equals>
+                <property>pax/right-passenger/present</property>
                 <property>sim/model/occupants</property>
             </and>
         </condition>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -5232,7 +5232,7 @@
         </offsets>
     </model>
 
-    <!-- Pilot not visible in the cockpit AND walker modes -->
+    <!-- Pilot not visible in the cockpit AND walker modes or if not enough weight on his seat -->
     <animation>
         <type>select</type>
         <object-name>Pilot</object-name>
@@ -5261,23 +5261,29 @@
                     <property>sim/current-view/name</property>
                     <value>Walker Orbit View</value>
                 </not-equals>
-
+                <property>pax/pilot/present</property>
                 <property>sim/model/occupants</property>
             </and>
         </condition>
     </animation>
 
-    <!-- Co-pilot and passangers not visible if not enough weight on his seat -->
+    <!-- Co-pilot not visible if not enough weight on his seat or if uing Cockpit Right Seat View-->
     <animation>
         <type>select</type>
         <object-name>Copilot</object-name>
         <condition>
             <and>
+                <not-equals>
+                    <property>sim/current-view/name</property>
+                    <value>Cockpit Right Seat View</value>
+                </not-equals>
                 <property>pax/co-pilot/present</property>
                 <property>sim/model/occupants</property>
             </and>
         </condition>
     </animation>
+    
+    <!-- Passangers not visible if not enough weight on his seat -->
     <animation>
         <type>select</type>
         <object-name>LeftPassenger</object-name>

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -201,12 +201,14 @@ var update_pax = func {
     state = bits.switch(state, 0, getprop("pax/co-pilot/present"));
     state = bits.switch(state, 1, getprop("pax/left-passenger/present"));
     state = bits.switch(state, 2, getprop("pax/right-passenger/present"));
+    state = bits.switch(state, 3, getprop("pax/pilot/present"));
     setprop("/payload/pax-state", state);
 };
 
 setlistener("/pax/co-pilot/present", update_pax, 0, 0);
 setlistener("/pax/left-passenger/present", update_pax, 0, 0);
 setlistener("/pax/right-passenger/present", update_pax, 0, 0);
+setlistener("/pax/pilot/present", update_pax, 0, 0);
 update_pax();
 
 var nasalInit = setlistener("/sim/signals/fdm-initialized", func{

--- a/Systems/pax.xml
+++ b/Systems/pax.xml
@@ -20,6 +20,19 @@
 <PropertyList>
 
     <logic>
+        <name>Pilot Present</name>
+        <input>
+            <greater-than>
+                <property>payload/weight[0]/weight-lb</property>
+                <value>100.0</value>
+            </greater-than>
+        </input>
+        <output>
+            <property>pax/pilot/present</property>
+        </output>
+    </logic>
+
+    <logic>
         <name>Co-Pilot Present</name>
         <input>
             <greater-than>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -205,6 +205,35 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
                 <default-field-of-view-deg>73.6</default-field-of-view-deg>
             </config>
         </view>
+        
+        <!-- Position the co-pilot viewpoint and angle -->
+        <view n="1">
+            <name>Cockpit Right Seat View</name>
+            <type>lookfrom</type>
+            <internal type="bool">true</internal>
+            <config>
+                <from-model type="bool">true</from-model>
+                <from-model-idx type="int">0</from-model-idx>
+                <x-offset-m type="double">0.23</x-offset-m>
+                <y-offset-m type="double">0.19</y-offset-m>
+                <z-offset-m type="double">0.35</z-offset-m>
+                <pitch-offset-deg type="double">-12</pitch-offset-deg>
+                <default-field-of-view-deg>73.6</default-field-of-view-deg>
+                <limits>
+                    <enabled type="bool">true</enabled>
+                    <left>
+                        <heading-max-deg type="double">140</heading-max-deg>
+                        <x-offset-max-m type="double">0.15</x-offset-max-m>
+                        <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                    </left>
+                    <right>
+                        <heading-max-deg type="double">140</heading-max-deg>
+                        <x-offset-max-m type="double">0.15</x-offset-max-m>
+                        <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                    </right>
+                </limits>
+            </config>
+        </view>
 
         <systems>
             <path>Aircraft/c172p/Systems/systems.xml</path>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -18,7 +18,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 
 <PropertyList include="Aircraft/Generic/Human/Include/walker-include.xml">
 
-    <sim>
+    <sim include="c172p-views.xml">
         <description>Cessna 172P Skyhawk (1981 model, detailed)</description>
 
         <long-description>The Cessna 172 Skyhawk is a four-seat, single-engine, high-wing fixed-wing aircraft. 
@@ -193,105 +193,6 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <panel>
             <visibility type="bool" archive="y">false</visibility>
         </panel>
-
-        <!-- Position the pilot viewpoint and angle -->
-        <view>
-            <internal type="bool" archive="y">true</internal>
-            <config>
-                <x-offset-m archive="y" type="double">-0.21</x-offset-m>
-                <y-offset-m archive="y" type="double">0.19</y-offset-m>
-                <z-offset-m archive="y" type="double">0.36</z-offset-m>
-                <pitch-offset-deg type="double">-12</pitch-offset-deg>
-                <default-field-of-view-deg>73.6</default-field-of-view-deg>
-            </config>
-        </view>
-        
-        <!-- Position the co-pilot viewpoint and angle -->
-        <view n="1">
-            <name>Cockpit Right Seat View</name>
-            <type>lookfrom</type>
-            <internal type="bool">true</internal>
-            <config>
-                <from-model type="bool">true</from-model>
-                <from-model-idx type="int">0</from-model-idx>
-                <x-offset-m type="double">0.23</x-offset-m>
-                <y-offset-m type="double">0.19</y-offset-m>
-                <z-offset-m type="double">0.36</z-offset-m>
-                <pitch-offset-deg type="double">-12</pitch-offset-deg>
-                <default-field-of-view-deg>73.6</default-field-of-view-deg>
-                <limits>
-                    <enabled type="bool">true</enabled>
-                    <left>
-                        <heading-max-deg type="double">140</heading-max-deg>
-                        <x-offset-max-m type="double">0.15</x-offset-max-m>
-                        <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
-                    </left>
-                    <right>
-                        <heading-max-deg type="double">140</heading-max-deg>
-                        <x-offset-max-m type="double">0.15</x-offset-max-m>
-                        <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
-                    </right>
-                </limits>
-            </config>
-        </view>
-        
-        <!-- Position the left passenger viewpoint and angle -->
-        <view n="2">
-            <name>Left Passenger Seat View</name>
-            <type>lookfrom</type>
-            <internal type="bool">true</internal>
-            <config>
-                <from-model type="bool">true</from-model>
-                <from-model-idx type="int">0</from-model-idx>
-                <x-offset-m type="double">-0.19</x-offset-m>
-                <y-offset-m type="double">0.15</y-offset-m>
-                <z-offset-m type="double">1.05</z-offset-m>
-                <pitch-offset-deg type="double">-12</pitch-offset-deg>
-                <default-field-of-view-deg>73.6</default-field-of-view-deg>
-                <limits>
-                    <enabled type="bool">true</enabled>
-                    <left>
-                        <heading-max-deg type="double">140</heading-max-deg>
-                        <x-offset-max-m type="double">0.15</x-offset-max-m>
-                        <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
-                    </left>
-                    <right>
-                        <heading-max-deg type="double">140</heading-max-deg>
-                        <x-offset-max-m type="double">0.15</x-offset-max-m>
-                        <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
-                    </right>
-                </limits>
-            </config>
-        </view>
-        
-        <!-- Position the right passenger viewpoint and angle -->
-        <view n="3">
-            <name>Right Passenger Seat View</name>
-            <type>lookfrom</type>
-            <internal type="bool">true</internal>
-            <config>
-                <from-model type="bool">true</from-model>
-                <from-model-idx type="int">0</from-model-idx>
-                <x-offset-m type="double">0.21</x-offset-m>
-                <y-offset-m type="double">0.15</y-offset-m>
-                <z-offset-m type="double">1.05</z-offset-m>
-                <pitch-offset-deg type="double">-12</pitch-offset-deg>
-                <default-field-of-view-deg>73.6</default-field-of-view-deg>
-                <limits>
-                    <enabled type="bool">true</enabled>
-                    <left>
-                        <heading-max-deg type="double">140</heading-max-deg>
-                        <x-offset-max-m type="double">0.15</x-offset-max-m>
-                        <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
-                    </left>
-                    <right>
-                        <heading-max-deg type="double">140</heading-max-deg>
-                        <x-offset-max-m type="double">0.15</x-offset-max-m>
-                        <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
-                    </right>
-                </limits>
-            </config>
-        </view>
 
         <systems>
             <path>Aircraft/c172p/Systems/systems.xml</path>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -216,7 +216,65 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
                 <from-model-idx type="int">0</from-model-idx>
                 <x-offset-m type="double">0.23</x-offset-m>
                 <y-offset-m type="double">0.19</y-offset-m>
-                <z-offset-m type="double">0.35</z-offset-m>
+                <z-offset-m type="double">0.36</z-offset-m>
+                <pitch-offset-deg type="double">-12</pitch-offset-deg>
+                <default-field-of-view-deg>73.6</default-field-of-view-deg>
+                <limits>
+                    <enabled type="bool">true</enabled>
+                    <left>
+                        <heading-max-deg type="double">140</heading-max-deg>
+                        <x-offset-max-m type="double">0.15</x-offset-max-m>
+                        <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                    </left>
+                    <right>
+                        <heading-max-deg type="double">140</heading-max-deg>
+                        <x-offset-max-m type="double">0.15</x-offset-max-m>
+                        <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                    </right>
+                </limits>
+            </config>
+        </view>
+        
+        <!-- Position the left passenger viewpoint and angle -->
+        <view n="2">
+            <name>Left Passenger Seat View</name>
+            <type>lookfrom</type>
+            <internal type="bool">true</internal>
+            <config>
+                <from-model type="bool">true</from-model>
+                <from-model-idx type="int">0</from-model-idx>
+                <x-offset-m type="double">-0.19</x-offset-m>
+                <y-offset-m type="double">0.15</y-offset-m>
+                <z-offset-m type="double">1.05</z-offset-m>
+                <pitch-offset-deg type="double">-12</pitch-offset-deg>
+                <default-field-of-view-deg>73.6</default-field-of-view-deg>
+                <limits>
+                    <enabled type="bool">true</enabled>
+                    <left>
+                        <heading-max-deg type="double">140</heading-max-deg>
+                        <x-offset-max-m type="double">0.15</x-offset-max-m>
+                        <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                    </left>
+                    <right>
+                        <heading-max-deg type="double">140</heading-max-deg>
+                        <x-offset-max-m type="double">0.15</x-offset-max-m>
+                        <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                    </right>
+                </limits>
+            </config>
+        </view>
+        
+        <!-- Position the right passenger viewpoint and angle -->
+        <view n="3">
+            <name>Right Passenger Seat View</name>
+            <type>lookfrom</type>
+            <internal type="bool">true</internal>
+            <config>
+                <from-model type="bool">true</from-model>
+                <from-model-idx type="int">0</from-model-idx>
+                <x-offset-m type="double">0.21</x-offset-m>
+                <y-offset-m type="double">0.15</y-offset-m>
+                <z-offset-m type="double">1.05</z-offset-m>
                 <pitch-offset-deg type="double">-12</pitch-offset-deg>
                 <default-field-of-view-deg>73.6</default-field-of-view-deg>
                 <limits>

--- a/c172p-views.xml
+++ b/c172p-views.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<PropertyList>
+
+    <!-- Position the pilot viewpoint and angle -->
+    <view>
+        <internal type="bool" archive="y">true</internal>
+        <config>
+            <x-offset-m archive="y" type="double">-0.21</x-offset-m>
+            <y-offset-m archive="y" type="double">0.19</y-offset-m>
+            <z-offset-m archive="y" type="double">0.36</z-offset-m>
+            <pitch-offset-deg type="double">-12</pitch-offset-deg>
+            <default-field-of-view-deg>73.6</default-field-of-view-deg>
+        </config>
+    </view>
+
+    <!-- Position the co-pilot viewpoint and angle -->
+    <view n="101">
+        <name>Cockpit Right Seat View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <x-offset-m type="double">0.23</x-offset-m>
+            <y-offset-m type="double">0.19</y-offset-m>
+            <z-offset-m type="double">0.36</z-offset-m>
+            <pitch-offset-deg type="double">-12</pitch-offset-deg>
+            <default-field-of-view-deg>73.6</default-field-of-view-deg>
+            <limits>
+                <enabled type="bool">true</enabled>
+                <left>
+                    <heading-max-deg type="double">140</heading-max-deg>
+                    <x-offset-max-m type="double">0.15</x-offset-max-m>
+                    <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                </left>
+                <right>
+                    <heading-max-deg type="double">140</heading-max-deg>
+                    <x-offset-max-m type="double">0.15</x-offset-max-m>
+                    <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                </right>
+            </limits>
+        </config>
+    </view>
+
+    <!-- Position the left passenger viewpoint and angle -->
+    <view n="102">
+        <name>Left Passenger Seat View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <x-offset-m type="double">-0.19</x-offset-m>
+            <y-offset-m type="double">0.15</y-offset-m>
+            <z-offset-m type="double">1.05</z-offset-m>
+            <pitch-offset-deg type="double">-12</pitch-offset-deg>
+            <default-field-of-view-deg>73.6</default-field-of-view-deg>
+            <limits>
+                <enabled type="bool">true</enabled>
+                <left>
+                    <heading-max-deg type="double">140</heading-max-deg>
+                    <x-offset-max-m type="double">0.15</x-offset-max-m>
+                    <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                </left>
+                <right>
+                    <heading-max-deg type="double">140</heading-max-deg>
+                    <x-offset-max-m type="double">0.15</x-offset-max-m>
+                    <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                </right>
+            </limits>
+        </config>
+    </view>
+
+    <!-- Position the right passenger viewpoint and angle -->
+    <view n="103">
+        <name>Right Passenger Seat View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <x-offset-m type="double">0.21</x-offset-m>
+            <y-offset-m type="double">0.15</y-offset-m>
+            <z-offset-m type="double">1.05</z-offset-m>
+            <pitch-offset-deg type="double">-12</pitch-offset-deg>
+            <default-field-of-view-deg>73.6</default-field-of-view-deg>
+            <limits>
+                <enabled type="bool">true</enabled>
+                <left>
+                    <heading-max-deg type="double">140</heading-max-deg>
+                    <x-offset-max-m type="double">0.15</x-offset-max-m>
+                    <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                </left>
+                <right>
+                    <heading-max-deg type="double">140</heading-max-deg>
+                    <x-offset-max-m type="double">0.15</x-offset-max-m>
+                    <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                </right>
+            </limits>
+        </config>
+    </view>
+
+</PropertyList>

--- a/c172p-views.xml
+++ b/c172p-views.xml
@@ -14,37 +14,8 @@
         </config>
     </view>
 
-    <!-- Position the co-pilot viewpoint and angle -->
-    <view n="101">
-        <name>Cockpit Right Seat View</name>
-        <type>lookfrom</type>
-        <internal type="bool">true</internal>
-        <config>
-            <from-model type="bool">true</from-model>
-            <from-model-idx type="int">0</from-model-idx>
-            <x-offset-m type="double">0.23</x-offset-m>
-            <y-offset-m type="double">0.19</y-offset-m>
-            <z-offset-m type="double">0.36</z-offset-m>
-            <pitch-offset-deg type="double">-12</pitch-offset-deg>
-            <default-field-of-view-deg>73.6</default-field-of-view-deg>
-            <limits>
-                <enabled type="bool">true</enabled>
-                <left>
-                    <heading-max-deg type="double">140</heading-max-deg>
-                    <x-offset-max-m type="double">0.15</x-offset-max-m>
-                    <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
-                </left>
-                <right>
-                    <heading-max-deg type="double">140</heading-max-deg>
-                    <x-offset-max-m type="double">0.15</x-offset-max-m>
-                    <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
-                </right>
-            </limits>
-        </config>
-    </view>
-
     <!-- Position the left passenger viewpoint and angle -->
-    <view n="102">
+    <view n="100">
         <name>Left Passenger Seat View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -73,7 +44,7 @@
     </view>
 
     <!-- Position the right passenger viewpoint and angle -->
-    <view n="103">
+    <view n="101">
         <name>Right Passenger Seat View</name>
         <type>lookfrom</type>
         <internal type="bool">true</internal>
@@ -83,6 +54,35 @@
             <x-offset-m type="double">0.21</x-offset-m>
             <y-offset-m type="double">0.15</y-offset-m>
             <z-offset-m type="double">1.05</z-offset-m>
+            <pitch-offset-deg type="double">-12</pitch-offset-deg>
+            <default-field-of-view-deg>73.6</default-field-of-view-deg>
+            <limits>
+                <enabled type="bool">true</enabled>
+                <left>
+                    <heading-max-deg type="double">140</heading-max-deg>
+                    <x-offset-max-m type="double">0.15</x-offset-max-m>
+                    <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                </left>
+                <right>
+                    <heading-max-deg type="double">140</heading-max-deg>
+                    <x-offset-max-m type="double">0.15</x-offset-max-m>
+                    <x-offset-threshold-deg type="double">65</x-offset-threshold-deg>
+                </right>
+            </limits>
+        </config>
+    </view>
+
+    <!-- Position the co-pilot viewpoint and angle -->
+    <view n="102">
+        <name>Cockpit Right Seat View</name>
+        <type>lookfrom</type>
+        <internal type="bool">true</internal>
+        <config>
+            <from-model type="bool">true</from-model>
+            <from-model-idx type="int">0</from-model-idx>
+            <x-offset-m type="double">0.23</x-offset-m>
+            <y-offset-m type="double">0.19</y-offset-m>
+            <z-offset-m type="double">0.36</z-offset-m>
             <pitch-offset-deg type="double">-12</pitch-offset-deg>
             <default-field-of-view-deg>73.6</default-field-of-view-deg>
             <limits>


### PR DESCRIPTION
Creates a Cockpit Right Seat View. For this to work well, I also made the pilot model dependent of its weight (so that one can set 100 pounds of weight to the right seat and less than 100 pounds to the left seat and have an empty pilot chair). 

Fixes #416.