### PR TITLE
Tail skid contact height

### DIFF
--- a/c172p.xml
+++ b/c172p.xml
@@ -260,7 +260,7 @@
             <location unit="IN">
                 <x> 226.7 </x>
                 <y> 0 </y>
-                <z> 8 </z>
+                <z> 17 </z>
             </location>
             <static_friction> 0.5 </static_friction>
             <dynamic_friction> 0.25 </dynamic_friction>


### PR DESCRIPTION
Z-contact by the tail skid in the FDM was too low (z=8), which made it "touch" the ground prematurely (see external view by rolling at very high pitch-up angle). 

![tail-skid-contact](https://cloud.githubusercontent.com/assets/11994061/10737762/4cf059ce-7c14-11e5-9a72-2b5f67d42b1d.png)


More importantly, it prevented from reaching a high pitch-up angle at landing (slow speed when grazing the ground, down to stall).

By changing for z=15 ==> Accordance between FDM and 3D view contacts, and very soft touching down at slower speed, higher AoA becomes possible at landing by progressively pulling the yoke so to pitch up and hold the plane.