### PR TITLE
Use mouse scroll wheel to zoom in and out for 'lookat' views

### DIFF
--- a/Systems/views.xml
+++ b/Systems/views.xml
@@ -45,6 +45,10 @@
                 </not-equals>
                 <not-equals>
                     <property>/sim/current-view/name</property>
+                    <value>Chase View Without Yaw</value>
+                </not-equals>
+                <not-equals>
+                    <property>/sim/current-view/name</property>
                     <value>Walk View</value>
                 </not-equals>
             </and>

--- a/Systems/views.xml
+++ b/Systems/views.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright (c) 2015 onox
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<PropertyList>
+
+    <!-- ================================================================== -->
+    <!-- Scroll Wheel Zooming                                               -->
+    <!-- ================================================================== -->
+
+    <logic>
+        <name>View Zoom Enabled</name>
+        <input>
+            <and>
+                <equals>
+                    <property>/sim/current-view/type</property>
+                    <value>lookat</value>
+                </equals>
+                <not-equals>
+                    <property>/sim/current-view/name</property>
+                    <value>Tower View</value>
+                </not-equals>
+                <not-equals>
+                    <property>/sim/current-view/name</property>
+                    <value>Fly-By View</value>
+                </not-equals>
+                <not-equals>
+                    <property>/sim/current-view/name</property>
+                    <value>Chase View</value>
+                </not-equals>
+                <not-equals>
+                    <property>/sim/current-view/name</property>
+                    <value>Walk View</value>
+                </not-equals>
+            </and>
+        </input>
+        <output>
+            <property>/sim/current-view/can-change-z-offset</property>
+        </output>
+    </logic>
+
+    <filter>
+        <name>View Zoom Decrease Step</name>
+        <type>gain</type>
+        <input>
+            <condition>
+                <less-than-equals>
+                    <property>/sim/current-view/z-offset-m</property>
+                    <value>-50.0</value>
+                </less-than-equals>
+            </condition>
+            <value>-10.0</value>
+        </input>
+        <input>
+            <condition>
+                <less-than-equals>
+                    <property>/sim/current-view/z-offset-m</property>
+                    <value>-15.0</value>
+                </less-than-equals>
+            </condition>
+            <value>-5.0</value>
+        </input>
+        <input>
+            <value>-2.0</value>
+        </input>
+        <output>
+            <property>/sim/current-view/z-offset-dec-step</property>
+        </output>
+    </filter>
+
+    <filter>
+        <name>View Zoom Increase Step</name>
+        <type>gain</type>
+        <input>
+            <condition>
+                <less-than>
+                    <property>/sim/current-view/z-offset-m</property>
+                    <value>-50.0</value>
+                </less-than>
+            </condition>
+            <value>10.0</value>
+        </input>
+        <input>
+            <condition>
+                <less-than>
+                    <property>/sim/current-view/z-offset-m</property>
+                    <value>-15.0</value>
+                </less-than>
+            </condition>
+            <value>5.0</value>
+        </input>
+        <input>
+            <value>2.0</value>
+        </input>
+        <output>
+            <property>/sim/current-view/z-offset-inc-step</property>
+        </output>
+    </filter>
+
+</PropertyList>

--- a/c172p-mice.xml
+++ b/c172p-mice.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Copyright (c) 2015 onox
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<PropertyList>
+
+    <mouse n="0">
+
+        <mode n="0">
+            <button n="3">
+                <binding n="0">
+                    <script></script>
+                </binding>
+                <binding n="1">
+                    <condition>
+                        <property>/sim/current-view/can-change-z-offset</property>
+                    </condition>
+                    <command>nasal</command>
+                    <script>
+                        var distance = getprop("/sim/current-view/z-offset-m");
+                        var multiple = getprop("/sim/current-view/z-offset-inc-step");
+                        var min_dist = getprop("/sim/current-view/z-offset-min-m");
+
+                        # Round distance to a multiple of the step
+                        distance = math.round(std.min(-min_dist, distance + multiple) / multiple) * multiple;
+                        setprop("/sim/current-view/z-offset-m", distance);
+
+                        gui.popupTip(sprintf("%d meter", abs(getprop("/sim/current-view/z-offset-m"))));
+                    </script>
+                </binding>
+            </button>
+
+            <button n="4">
+                <binding n="0">
+                    <script></script>
+                </binding>
+                <binding n="1">
+                    <condition>
+                        <property>/sim/current-view/can-change-z-offset</property>
+                    </condition>
+                    <command>nasal</command>
+                    <script>
+                        var distance = getprop("/sim/current-view/z-offset-m");
+                        var multiple = getprop("/sim/current-view/z-offset-dec-step");
+                        var max_dist = getprop("/sim/current-view/z-offset-max-m");
+
+                        # Round distance to a multiple of the step
+                        distance = math.round(std.max(-max_dist, distance + multiple) / multiple) * multiple;
+                        setprop("/sim/current-view/z-offset-m", distance);
+
+                        gui.popupTip(sprintf("%d meter", abs(getprop("/sim/current-view/z-offset-m"))));
+                    </script>
+                </binding>
+            </button>
+        </mode>
+
+    </mouse>
+
+</PropertyList>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -179,6 +179,15 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <path>/fdm/jsbsim/weather</path>
         </aircraft-data>
 
+        <current-view>
+            <z-offset-dec-step type="double">0.0</z-offset-dec-step>
+            <z-offset-inc-step type="double">0.0</z-offset-inc-step>
+            <can-change-z-offset type="bool">false</can-change-z-offset>
+
+            <z-offset-min-m type="float">5.0</z-offset-min-m>
+            <z-offset-max-m type="float">150.0</z-offset-max-m>
+        </current-view>
+
         <!-- Splash screens. One is randomly chosen when FlightGear starts -->
         <startup>
             <splash-texture>Aircraft/c172p/splash1.png</splash-texture>
@@ -231,6 +240,10 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 
             <property-rule n="105">
                 <path>Aircraft/c172p/Systems/pax.xml</path>
+            </property-rule>
+
+            <property-rule n="106">
+                <path>Aircraft/c172p/Systems/views.xml</path>
             </property-rule>
         </systems>
 
@@ -689,6 +702,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 
     <input>
         <keyboard include="c172p-keyboard.xml"/>
+        <mice include="c172p-mice.xml"/>
     </input>
 
     <gear>


### PR DESCRIPTION
Fixes #476 

It works nicely with the external Helicopter View, Model View, and Walker Orbit View. Chase View gave weird results (distance as well as altitude of camera changes), so disabled it for that view.