### PR TITLE
Fix controls.applyParkingBrake

### DIFF
--- a/Nasal/avionics.nas
+++ b/Nasal/avionics.nas
@@ -127,7 +127,7 @@ aircraft.data.add(
     "/controls/anti-ice/pitot-heat",
     "/consumables/fuel/tank/selected",
     "/consumables/fuel/tank[1]/selected",
-    "/controls/gear/brake-parking",
+    "/sim/model/c172p/brake-parking",
     "/controls/flight/flaps",
     "/controls/flight/elevator-trim",
     "/controls/engines/current-engine/throttle",

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -16,17 +16,9 @@ controls.applyParkingBrake = func (v) {
         return;
     }
 
-    var left_broken = getprop("/fdm/jsbsim/gear/unit[1]/broken");
-    var right_broken =getprop("/fdm/jsbsim/gear/unit[2]/broken");
-    var p = "/controls/gear/brake-parking";
-    var orig_p = getprop(p);
-
-    # We assume one non-broken gear is enough to apply the parking brake
-    if (orig_p or !left_broken or !right_broken) {
-        setprop(p, var i = !orig_p);
-        return i;
-    }
-    return orig_p;
+    var p = "/sim/model/c172p/brake-parking";
+    setprop(p, var i = !getprop(p));
+    return i;
 };
 
 ##########################################
@@ -82,7 +74,6 @@ var switches_save_state = func {
         setprop("/controls/lighting/instruments-norm", 0.0);
         setprop("/controls/gear/water-rudder", 0);
         setprop("/controls/gear/water-rudder-down", 0);
-        setprop("/controls/gear/brake-parking", 0);
         setprop("/sim/model/c172p/brake-parking", 0);
         setprop("/controls/flight/flaps", 0.0);
         setprop("/surface-positions/flap-pos-norm", 0.0);

--- a/Systems/flight-recorder/components/switches.xml
+++ b/Systems/flight-recorder/components/switches.xml
@@ -6,6 +6,12 @@
     <!-- Switches                                                       -->
     <!-- ============================================================== -->
 
+    <!-- Parking brake -->
+    <signal>
+        <type>float</type>
+        <property type="string">/sim/model/c172p/brake-parking</property>
+    </signal>
+
     <signal>
         <type>bool</type>
         <property type="string">/controls/engines/engine/primer-lever</property>

--- a/Systems/ground-effects.xml
+++ b/Systems/ground-effects.xml
@@ -323,18 +323,24 @@ Under the GPL. Used by shadows under ALS -->
     </filter>
     
     <!-- logic for securing aircraft -->   
-     <logic>
-        <name>Parking Brake and chock</name>
+    <logic>
+        <name>Parking Brake And Chock</name>
         <input>
             <or>
+                <!-- The actual parking brake controlled by the pilot -->
                 <property>/sim/model/c172p/brake-parking</property>
+
                 <property>/sim/model/c172p/smallchock-visible</property>
                 <property>/sim/model/c172p/woodenchock-visible</property>
                 <property>/sim/model/c172p/tiedowns-visible</property>
+
+                <!-- A broken gear operates as a parking brake -->
+                <property>/fdm/jsbsim/gear/unit[1]/broken</property>
+                <property>/fdm/jsbsim/gear/unit[2]/broken</property>
             </or>
         </input>
         <output>
-            <property>controls/gear/brake-parking</property>
+            <property>/controls/gear/brake-parking</property>
         </output>
     </logic>
     


### PR DESCRIPTION
May fix #517 

@gilbertohasnofb Ask someguy if he can confirm. I'm assuming joystick code calls `controls.applyParkingBrake(1);` to toggle it. Both our function and the function we have overridden (`applyParkingBrake`) have one parameter that needs to be positive, but is otherwise unused.