### PR TITLE
Some improvements to the dialogs and autostart

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -2027,6 +2027,24 @@
             <button>0</button>
             <repeatable>false</repeatable>
             <binding>
+                <condition>
+                    <or>
+                        <equals>
+                            <property>/sim/model/door-positions/baggageDoor/position-norm</property>
+                            <value>1</value>
+                        </equals>
+                        <and>
+                            <equals>
+                                <property>/sim/model/door-positions/baggageDoor/position-norm</property>
+                                <value>0</value>
+                            </equals>
+                            <less-than>
+                                <property>velocities/groundspeed-kt</property>
+                                <value>1.0</value>
+                            </less-than>
+                        </and>
+                    </or>
+                </condition>
                 <command>nasal</command>
                 <script>c172p.baggageDoor.toggle();</script>
             </binding>

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -1,4 +1,50 @@
 ##########################################
+# Autostart
+##########################################
+
+var autostart = func (msg=1) {
+    if (getprop("/engines/active-engine/running")) {
+		if (msg)
+            gui.popupTip("Engine already running", 5);
+        return;
+    }
+
+    setprop("/controls/switches/magnetos", 3);
+    setprop("/controls/engines/current-engine/throttle", 0.2);
+    setprop("/controls/engines/current-engine/mixture", 1.0);
+    setprop("/controls/flight/elevator-trim", 0.0);
+    setprop("/controls/switches/master-bat", 1);
+    setprop("/controls/switches/master-alt", 1);
+    setprop("/controls/switches/master-avionics", 1);
+
+    setprop("/controls/lighting/nav-lights", 1);
+    setprop("/controls/lighting/strobe", 1);
+    setprop("/controls/lighting/beacon", 1);
+
+    setprop("/consumables/fuel/tank[0]/selected", 1);
+    setprop("/consumables/fuel/tank[1]/selected", 1);
+
+    # Set the altimeter
+    setprop("/instrumentation/altimeter/setting-inhg", getprop("/environment/pressure-sea-level-inhg"));
+
+    # Pre-flight inspection
+    setprop("/sim/model/c172p/brake-parking", 0);
+    setprop("/sim/model/c172p/chock", 0);
+    setprop("/sim/model/c172p/pitot-cover", 0);
+    setprop("/sim/model/c172p/tiedownL", 0);
+    setprop("/sim/model/c172p/tiedownR", 0);
+    setprop("/engines/active-engine/oil-level", 7.0);
+    setprop("/consumables/fuel/tank[0]/water-contamination", 0.0);
+    setprop("/consumables/fuel/tank[1]/water-contamination", 0.0);
+
+    #c172p.autoPrime();
+    setprop("/controls/engines/engine[0]/primer-lever", 0);
+    setprop("/controls/engines/engine/primer", 3);
+	if (msg)
+	    gui.popupTip("Hold down \"s\" to start the engine", 5);
+};
+
+##########################################
 # Brakes
 ##########################################
 

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -4,8 +4,8 @@
 
 var autostart = func (msg=1) {
     if (getprop("/engines/active-engine/running")) {
-		if (msg)
-            gui.popupTip("Engine already running", 5);
+    if (msg)
+        gui.popupTip("Engine already running", 5);
         return;
     }
 
@@ -40,8 +40,8 @@ var autostart = func (msg=1) {
     #c172p.autoPrime();
     setprop("/controls/engines/engine[0]/primer-lever", 0);
     setprop("/controls/engines/engine/primer", 3);
-	if (msg)
-	    gui.popupTip("Hold down \"s\" to start the engine", 5);
+    if (msg)
+        gui.popupTip("Hold down \"s\" to start the engine", 5);
 };
 
 ##########################################

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -130,7 +130,7 @@ var switches_save_state = func {
         setprop("/controls/lighting/instruments-norm", 0.0);
         setprop("/controls/gear/water-rudder", 0);
         setprop("/controls/gear/water-rudder-down", 0);
-        setprop("/sim/model/c172p/brake-parking", 0);
+        setprop("/sim/model/c172p/brake-parking", 1);
         setprop("/controls/flight/flaps", 0.0);
         setprop("/surface-positions/flap-pos-norm", 0.0);
         setprop("/controls/flight/elevator-trim", 0.0);

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -168,51 +168,9 @@ var update = func {
     }
 };
 
-var autostart = func (msg=1) {
-    if (getprop("/engines/active-engine/running")) {
-		if (msg)
-            gui.popupTip("Engine already running", 5);
-        return;
-    }
-
-    setprop("/controls/switches/magnetos", 3);
-    setprop("/controls/engines/current-engine/throttle", 0.2);
-    setprop("/controls/engines/current-engine/mixture", 1.0);
-    setprop("/controls/flight/elevator-trim", 0.0);
-    setprop("/controls/switches/master-bat", 1);
-    setprop("/controls/switches/master-alt", 1);
-    setprop("/controls/switches/master-avionics", 1);
-
-    setprop("/controls/lighting/nav-lights", 1);
-    setprop("/controls/lighting/strobe", 1);
-    setprop("/controls/lighting/beacon", 1);
-
-    setprop("/consumables/fuel/tank[0]/selected", 1);
-    setprop("/consumables/fuel/tank[1]/selected", 1);
-
-    # Set the altimeter
-    setprop("/instrumentation/altimeter/setting-inhg", getprop("/environment/pressure-sea-level-inhg"));
-
-    # Pre-flight inspection
-    setprop("/sim/model/c172p/brake-parking", 0);
-    setprop("/sim/model/c172p/chock", 0);
-    setprop("/sim/model/c172p/pitot-cover", 0);
-    setprop("/sim/model/c172p/tiedownL", 0);
-    setprop("/sim/model/c172p/tiedownR", 0);
-    setprop("/engines/active-engine/oil-level", 7.0);
-    setprop("/consumables/fuel/tank[0]/water-contamination", 0.0);
-    setprop("/consumables/fuel/tank[1]/water-contamination", 0.0);
-
-    #c172p.autoPrime();
-    setprop("/controls/engines/engine[0]/primer-lever", 0);
-    setprop("/controls/engines/engine/primer", 3);
-	if (msg)
-	    gui.popupTip("Hold down \"s\" to start the engine", 5);
-};
-
 setlistener("/controls/switches/starter", func {
 	if (!getprop("/fdm/jsbsim/complex"))
-	    autostart(0);
+	    c172p.autostart(0);
     var v = getprop("/controls/switches/starter") or 0;
     if (v == 0) {
         print("Starter off");

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -182,7 +182,13 @@ var autostart = func (msg=1) {
     setprop("/controls/switches/master-bat", 1);
     setprop("/controls/switches/master-alt", 1);
     setprop("/controls/switches/master-avionics", 1);
+
+    # Remove parking brakes, wheel chocks, pitot tube cover and tie-downs
     setprop("/sim/model/c172p/brake-parking", 0);
+    setprop("/sim/model/c172p/chock", 0);
+    setprop("/sim/model/c172p/pitot-cover", 0);
+    setprop("/sim/model/c172p/tiedownL", 0);
+    setprop("/sim/model/c172p/tiedownR", 0);
 
     setprop("/controls/lighting/nav-lights", 1);
     setprop("/controls/lighting/strobe", 1);

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -182,6 +182,7 @@ var autostart = func (msg=1) {
     setprop("/controls/switches/master-bat", 1);
     setprop("/controls/switches/master-alt", 1);
     setprop("/controls/switches/master-avionics", 1);
+    setprop("/sim/model/c172p/brake-parking", 0);
 
     setprop("/controls/lighting/nav-lights", 1);
     setprop("/controls/lighting/strobe", 1);

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -183,13 +183,6 @@ var autostart = func (msg=1) {
     setprop("/controls/switches/master-alt", 1);
     setprop("/controls/switches/master-avionics", 1);
 
-    # Remove parking brakes, wheel chocks, pitot tube cover and tie-downs
-    setprop("/sim/model/c172p/brake-parking", 0);
-    setprop("/sim/model/c172p/chock", 0);
-    setprop("/sim/model/c172p/pitot-cover", 0);
-    setprop("/sim/model/c172p/tiedownL", 0);
-    setprop("/sim/model/c172p/tiedownR", 0);
-
     setprop("/controls/lighting/nav-lights", 1);
     setprop("/controls/lighting/strobe", 1);
     setprop("/controls/lighting/beacon", 1);
@@ -199,6 +192,16 @@ var autostart = func (msg=1) {
 
     # Set the altimeter
     setprop("/instrumentation/altimeter/setting-inhg", getprop("/environment/pressure-sea-level-inhg"));
+
+    # Pre-flight inspection
+    setprop("/sim/model/c172p/brake-parking", 0);
+    setprop("/sim/model/c172p/chock", 0);
+    setprop("/sim/model/c172p/pitot-cover", 0);
+    setprop("/sim/model/c172p/tiedownL", 0);
+    setprop("/sim/model/c172p/tiedownR", 0);
+    setprop("/engines/active-engine/oil-level", 7.0);
+    setprop("/consumables/fuel/tank[0]/water-contamination", 0.0);
+    setprop("/consumables/fuel/tank[1]/water-contamination", 0.0);
 
     #c172p.autoPrime();
     setprop("/controls/engines/engine[0]/primer-lever", 0);

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -1,9 +1,7 @@
-
 # Manages the engine
 #
 # Fuel system: based on the Spitfire. Manages primer and negGCutoff
 # Hobbs meter
-
 
 # =============================== DEFINITIONS ===========================================
 
@@ -169,8 +167,8 @@ var update = func {
 };
 
 setlistener("/controls/switches/starter", func {
-	if (!getprop("/fdm/jsbsim/complex"))
-	    c172p.autostart(0);
+    if (!getprop("/fdm/jsbsim/complex"))
+        c172p.autostart(0);
     var v = getprop("/controls/switches/starter") or 0;
     if (v == 0) {
         print("Starter off");
@@ -232,13 +230,13 @@ controls.mixtureAxis = func {
 # fun fact: the key UP event can be overwriten!
 controls.startEngine = func(v = 1) {
     if (getprop("/engines/active-engine/running"))
-	{
+    {
         setprop("/controls/switches/starter", 0);
-		return;
-	}
-	else {
+        return;
+    }
+    else {
         setprop("/controls/switches/magnetos", 3);
-		setprop("/controls/switches/starter", v);
+        setprop("/controls/switches/starter", v);
     }
 };
 

--- a/Nasal/ki266.nas
+++ b/Nasal/ki266.nas
@@ -35,57 +35,57 @@
 
 var ki266 = {};
 ki266.new = func(idx) {
-  var obj = {};
-  obj.parents = [ki266];
+    var obj = {};
+    obj.parents = [ki266];
 
-  obj.rootNode = props.globals.getNode( "/instrumentation/dme[" ~ idx ~ "]", 1 );
+    obj.rootNode = props.globals.getNode( "/instrumentation/dme[" ~ idx ~ "]", 1 );
 
-  obj.powerNode = obj.rootNode.initNode( "power-btn", 1, "BOOL" );
-  obj.distNode = obj.rootNode.initNode( "indicated-distance-nm", 0.0 );
-  obj.timeNode = obj.rootNode.initNode( "indicated-time-min", 0.0 );
-  obj.ktsNode = obj.rootNode.initNode( "indicated-ground-speed-kt", 0.0 );
-  obj.minKtsNode = obj.rootNode.initNode( "switch-min-kts", 1, "BOOL" );
-  obj.minKtsDisplayNode = obj.rootNode.initNode( "min-kts-display", 0.0 );
-  obj.milesDisplayNode = obj.rootNode.initNode( "miles-display", 0.0 );
-  obj.leftDotNode = obj.rootNode.initNode( "left-dot", 0, "BOOL" );
-  aircraft.data.add( obj.powerNode, obj.minKtsNode );
+    obj.powerNode = obj.rootNode.initNode( "power-btn", 1, "BOOL" );
+    obj.distNode = obj.rootNode.initNode( "indicated-distance-nm", 0.0 );
+    obj.timeNode = obj.rootNode.initNode( "indicated-time-min", 0.0 );
+    obj.ktsNode = obj.rootNode.initNode( "indicated-ground-speed-kt", 0.0 );
+    obj.minKtsNode = obj.rootNode.initNode( "switch-min-kts", 1, "BOOL" );
+    obj.minKtsDisplayNode = obj.rootNode.initNode( "min-kts-display", 0.0 );
+    obj.milesDisplayNode = obj.rootNode.initNode( "miles-display", 0.0 );
+    obj.leftDotNode = obj.rootNode.initNode( "left-dot", 0, "BOOL" );
+    aircraft.data.add( obj.powerNode, obj.minKtsNode );
 
-  obj.update();
+    obj.update();
 
-  print( "KI266 dme indicator #" ~ idx ~ " initialized" ); 
-  return obj;
+    print( "KI266 dme indicator #" ~ idx ~ " initialized" ); 
+    return obj;
 };
 
 ki266.update = func {
-  var v = 0.0;
+    var v = 0.0;
 
-  if( me.minKtsNode.getValue() ) {
-    v = me.ktsNode.getValue();
-  } else {
-    v = me.timeNode.getValue();
-  }
-  if( v > 999.0 ) {
-    v = 999.0;
-  }
-  if( v < 0.0 ) {
-    v = 0.0;
-  }
-  me.minKtsDisplayNode.setIntValue( v );
+    if( me.minKtsNode.getValue() ) {
+       v = me.ktsNode.getValue();
+    } else {
+        v = me.timeNode.getValue();
+    }
+    if( v > 999.0 ) {
+       v = 999.0;
+    }
+    if( v < 0.0 ) {
+       v = 0.0;
+    }
+    me.minKtsDisplayNode.setIntValue( v );
 
-  v = me.distNode.getValue();
-  if( v > 999.9 ) {
-    v = 999.9;
-  }
-  if( v < 0.0 ) {
-    v = 0.0;
-  }
-  if( v < 100.0 ) {
-    me.milesDisplayNode.setIntValue( v * 10.0 );
-    me.leftDotNode.setBoolValue( 1 );
-  } else {
-    me.milesDisplayNode.setIntValue( v );
-    me.leftDotNode.setBoolValue( 0 );
-  }
+    v = me.distNode.getValue();
+    if( v > 999.9 ) {
+       v = 999.9;
+    }
+    if( v < 0.0 ) {
+       v = 0.0;
+    }
+    if( v < 100.0 ) {
+        me.milesDisplayNode.setIntValue( v * 10.0 );
+        me.leftDotNode.setBoolValue( 1 );
+    } else {
+        me.milesDisplayNode.setIntValue( v );
+        me.leftDotNode.setBoolValue( 0 );
+    }
 
-  settimer( func { me.update() }, 0.2 );
+    settimer( func { me.update() }, 0.2 );
 }

--- a/Nasal/kma20.nas
+++ b/Nasal/kma20.nas
@@ -24,18 +24,18 @@
 var kma20 = {};
 
 kma20.new = func(rootPath) {
-  var obj = {};
-  obj.parents = [kma20];
+    var obj = {};
+    obj.parents = [kma20];
 
-  setlistener(rootPath ~ "/com1", func(v) {setprop("/instrumentation/comm/volume",        0.7*(v.getValue() != 0));}, 1);
-  setlistener(rootPath ~ "/com2", func(v) {setprop("/instrumentation/comm[1]/volume",     0.7*(v.getValue() != 0));}, 1);
-  setlistener(rootPath ~ "/nav1", func(v) {setprop("/instrumentation/nav/audio-btn",          (v.getValue() != 0));}, 1);
-  setlistener(rootPath ~ "/nav2", func(v) {setprop("/instrumentation/nav[1]/audio-btn",       (v.getValue() != 0));}, 1);
-  setlistener(rootPath ~ "/adf",  func(v) {setprop("/instrumentation/adf/ident-audible",      (v.getValue() != 0));}, 1);
-  setlistener(rootPath ~ "/dme",  func(v) {setprop("/instrumentation/dme/ident",              (v.getValue() != 0));}, 1);
-  setlistener(rootPath ~ "/mkr",  func(v) {setprop("/instrumentation/marker-beacon/audio-btn",(v.getValue() != 0));}, 1);
-  print( "KMA20 audio panel initialized" );
-  return obj;
+    setlistener(rootPath ~ "/com1", func(v) {setprop("/instrumentation/comm/volume",        0.7*(v.getValue() != 0));}, 1);
+    setlistener(rootPath ~ "/com2", func(v) {setprop("/instrumentation/comm[1]/volume",     0.7*(v.getValue() != 0));}, 1);
+    setlistener(rootPath ~ "/nav1", func(v) {setprop("/instrumentation/nav/audio-btn",          (v.getValue() != 0));}, 1);
+    setlistener(rootPath ~ "/nav2", func(v) {setprop("/instrumentation/nav[1]/audio-btn",       (v.getValue() != 0));}, 1);
+    setlistener(rootPath ~ "/adf",  func(v) {setprop("/instrumentation/adf/ident-audible",      (v.getValue() != 0));}, 1);
+    setlistener(rootPath ~ "/dme",  func(v) {setprop("/instrumentation/dme/ident",              (v.getValue() != 0));}, 1);
+    setlistener(rootPath ~ "/mkr",  func(v) {setprop("/instrumentation/marker-beacon/audio-btn",(v.getValue() != 0));}, 1);
+    print( "KMA20 audio panel initialized" );
+    return obj;
 };
 
 var kma20_0 = kma20.new( "/instrumentation/kma20" );

--- a/Nasal/kr87.nas
+++ b/Nasal/kr87.nas
@@ -9,56 +9,56 @@
 var elapsedTimeSecN = props.globals.getNode( "/sim/time/elapsed-sec" );
 
 var timer = {
-  new : func(base) {
-    var m = { parents: [timer] };
-    m.base = base;
-    m.baseN = props.globals.getNode( m.base, 1 );
+    new : func(base) {
+        var m = { parents: [timer] };
+        m.base = base;
+        m.baseN = props.globals.getNode( m.base, 1 );
 
-    m.timeN = m.baseN.initNode( "time", 0.0 );
-    m.runningN = m.baseN.initNode( "running", 0, "BOOL" );
-    m.startTimeN = m.baseN.initNode( "start-time", -1.0 );
+        m.timeN = m.baseN.initNode( "time", 0.0 );
+        m.runningN = m.baseN.initNode( "running", 0, "BOOL" );
+        m.startTimeN = m.baseN.initNode( "start-time", -1.0 );
 
-    return m;
-  },
+        return m;
+    },
 
-  getTime : func {
-    return me.timeN.getDoubleValue();
-  },
+    getTime : func {
+       return me.timeN.getDoubleValue();
+    },
 
-  start : func { 
-    me.runningN.setBoolValue( 1 );
-  },
+    start : func { 
+       me.runningN.setBoolValue( 1 );
+    },
 
-  stop : func { 
-    me.runningN.setBoolValue( 0 ); 
-  },
+    stop : func { 
+       me.runningN.setBoolValue( 0 ); 
+    },
 
-  reset : func {
-    me.startTimeN.setDoubleValue( elapsedTimeSecN.getValue() );
-    me.timeN.setDoubleValue( 0 );
-  },
+    reset : func {
+        me.startTimeN.setDoubleValue( elapsedTimeSecN.getValue() );
+        me.timeN.setDoubleValue( 0 );
+    },
 
-  restart : func {
-    me.reset();
-    me.start();
-  },
+    restart : func {
+        me.reset();
+        me.start();
+    },
 
-  # return integer coded time as hmmss
-  computeBCDTime : func {
-    var t = me.timeN.getValue();
-    var h = int(t / 3600);
-    var t = t - (h*3600);
-    var m = int(t / 60 );
-    var t = t - (m*60);
-    var s = int(t);
-    return h * 10000 + m * 100 + s;
-  },
+    # return integer coded time as hmmss
+    computeBCDTime : func {
+        var t = me.timeN.getValue();
+        var h = int(t / 3600);
+        var t = t - (h*3600);
+        var m = int(t / 60 );
+        var t = t - (m*60);
+        var s = int(t);
+        return h * 10000 + m * 100 + s;
+    },
 
-  update : func {
-    if( me.runningN.getValue() ) {
-      me.timeN.setDoubleValue( elapsedTimeSecN.getValue() - me.startTimeN.getValue() );
-    }
-  }
+    update : func {
+        if( me.runningN.getValue() ) {
+            me.timeN.setDoubleValue( elapsedTimeSecN.getValue() - me.startTimeN.getValue() );
+        }
+      }
 
 };
 
@@ -66,119 +66,118 @@ var timer = {
 # KR87
 
 var kr87 = {
-  new : func(base) {
-    var m = { parents: [kr87] };
-    m.base = base;
-    m.baseN = props.globals.getNode( m.base, 1 );
+    new : func(base) {
+        var m = { parents: [kr87] };
+        m.base = base;
+        m.baseN = props.globals.getNode( m.base, 1 );
 
-    m.flt = timer.new( m.base ~ "/flight-timer" );
-    m.flt.restart();
-    m.et  = timer.new( m.base ~ "/enroute-timer" );
-    m.et.restart();
+        m.flt = timer.new( m.base ~ "/flight-timer" );
+        m.flt.restart();
+        m.et  = timer.new( m.base ~ "/enroute-timer" );
+        m.et.restart();
 
-    m.displayModeN = m.baseN.initNode( "display-mode", 0, "INT" );
+        m.displayModeN = m.baseN.initNode( "display-mode", 0, "INT" );
 
-    m.rightDisplayN = m.baseN.getNode( "right-display", 1 );
-    m.standbyFrequencyN = m.baseN.getNode( "frequencies/standby-khz", 1 );
+        m.rightDisplayN = m.baseN.getNode( "right-display", 1 );
+        m.standbyFrequencyN = m.baseN.getNode( "frequencies/standby-khz", 1 );
 
-#   will be set from audiopanel
-#    m.baseN.getNode( "ident-audible" ).setBoolValue( 1 );
-    m.volumeNormN = m.baseN.initNode( "volume-norm", 0.0 );
+        # will be set from audiopanel
+        # m.baseN.getNode( "ident-audible" ).setBoolValue( 1 );
+        m.volumeNormN = m.baseN.initNode( "volume-norm", 0.0 );
 
-    m.power = 0;
+        m.power = 0;
 
-    m.powerButtonN = m.baseN.initNode( "power-btn", 0, "BOOL" ); 
-    m.powerButtonN.setBoolValue( m.volumeNormN.getValue() != 0 );
-    m.setButtonN = m.baseN.initNode( "set-btn", 0, "BOOL" );
-    m.powerButtonN.setBoolValue( m.powerButtonN.getValue() );
-    m.adfButtonN = m.baseN.initNode( "adf-btn", 0, "BOOL" );
-    m.bfoButtonN = m.baseN.initNode( "bfo-btn", 0, "BOOL" );
+        m.powerButtonN = m.baseN.initNode( "power-btn", 0, "BOOL" ); 
+        m.powerButtonN.setBoolValue( m.volumeNormN.getValue() != 0 );
+        m.setButtonN = m.baseN.initNode( "set-btn", 0, "BOOL" );
+        m.powerButtonN.setBoolValue( m.powerButtonN.getValue() );
+        m.adfButtonN = m.baseN.initNode( "adf-btn", 0, "BOOL" );
+        m.bfoButtonN = m.baseN.initNode( "bfo-btn", 0, "BOOL" );
 
-    m.modeN = m.baseN.getNode( "mode" );
-    aircraft.data.add(
-      m.adfButtonN,
-      m.bfoButtonN,
-      m.volumeNormN, 
-      m.powerButtonN,
-      m.standbyFrequencyN,
-      m.baseN.getNode( "frequencies/selected-khz", 1 )
-    );
-    setlistener( m.base ~ "/adf-btn", func { m.modeButtonListener() } );
-    setlistener( m.base ~ "/bfo-btn", func { m.modeButtonListener() } );
-    m.modeButtonListener();
+        m.modeN = m.baseN.getNode( "mode" );
+        aircraft.data.add(
+            m.adfButtonN,
+            m.bfoButtonN,
+            m.volumeNormN, 
+            m.powerButtonN,
+            m.standbyFrequencyN,
+            m.baseN.getNode( "frequencies/selected-khz", 1 )
+        );
+        setlistener( m.base ~ "/adf-btn", func { m.modeButtonListener() } );
+        setlistener( m.base ~ "/bfo-btn", func { m.modeButtonListener() } );
+        m.modeButtonListener();
 
-    return m;
-  },
+        return m;
+    },
 
-  modeButtonListener : func {
-    if( me.adfButtonN.getBoolValue() ) {
-      if( me.bfoButtonN.getBoolValue() ) {
-        me.modeN.setValue( "bfo" );
-      } else {
-        me.modeN.setValue( "adf" );
-      }
-    } else {
-      me.modeN.setValue( "ant" );
+    modeButtonListener : func {
+        if( me.adfButtonN.getBoolValue() ) {
+            if( me.bfoButtonN.getBoolValue() ) {
+               me.modeN.setValue( "bfo" );
+            } else {
+                me.modeN.setValue( "adf" );
+            }
+        } else {
+           me.modeN.setValue( "ant" );
+        }
+    },
+
+    powerButtonListener : func(n) {
+        if( n.getBoolValue() and !me.power ) {
+            # power on, restart timer and start with FRQ display
+            me.et.restart();
+            me.flt.restart();
+            me.displayModeN.setIntValue( 0 );
+          }
+        me.power = me.powerButtonN.getValue();
+    },
+
+    update : func {
+        me.flt.update();
+        me.et.update(); 
+        var m = me.displayModeN.getValue();
+
+        if( m == 0 ) {
+            # FRQ
+            me.rightDisplayN.setIntValue( me.standbyFrequencyN.getValue() );
+        } 
+
+        # the display works up to 99h, 59m, 59s and then
+        # displays 00:00 again. Don't know if this is the like the true kr87
+        # handles this - never flewn that long...
+        if( m == 1 ) {
+            # FLT, show mm:ss up to 59:59, then hh:mm
+            var t = me.flt.computeBCDTime();
+            if( t >= 10000 ) {
+               t = t / 100;
+            }
+            me.rightDisplayN.setIntValue( t );
+        } 
+        if( m == 2 ) {
+            # ET, show mm:ss up to 59:59, then hh:mm
+            t = me.et.computeBCDTime();
+            if( t >= 10000 ) {
+               t = t / 100;
+            }
+            me.rightDisplayN.setIntValue( t );
+        }
+
+        if( me.setButtonN.getValue() ) {
+           me.et.restart();
+        }
+
+        if( me.powerButtonN.getBoolValue() and !me.power ) {
+            # power on, restart timer and start with FRQ display
+            me.et.restart();
+            me.flt.restart();
+            me.displayModeN.setIntValue( 0 );
+        }
+        me.power = me.powerButtonN.getValue();
+
+        settimer( func { me.update() }, 0.1 );
     }
-  },
-
-  powerButtonListener : func(n) {
-    if( n.getBoolValue() and !me.power ) {
-      # power on, restart timer and start with FRQ display
-      me.et.restart();
-      me.flt.restart();
-      me.displayModeN.setIntValue( 0 );
-    }
-    me.power = me.powerButtonN.getValue();
-  },
-
-  update : func {
-    me.flt.update();
-    me.et.update(); 
-    var m = me.displayModeN.getValue();
-
-    if( m == 0 ) {
-      # FRQ
-      me.rightDisplayN.setIntValue( me.standbyFrequencyN.getValue() );
-    } 
-
-    # the display works up to 99h, 59m, 59s and then
-    # displays 00:00 again. Don't know if this is the like the true kr87
-    # handles this - never flewn that long...
-    if( m == 1 ) {
-      # FLT, show mm:ss up to 59:59, then hh:mm
-      var t = me.flt.computeBCDTime();
-      if( t >= 10000 ) {
-        t = t / 100;
-      }
-      me.rightDisplayN.setIntValue( t );
-    } 
-    if( m == 2 ) {
-      # ET, show mm:ss up to 59:59, then hh:mm
-      t = me.et.computeBCDTime();
-      if( t >= 10000 ) {
-        t = t / 100;
-      }
-      me.rightDisplayN.setIntValue( t );
-    }
-
-    if( me.setButtonN.getValue() ) {
-      me.et.restart();
-    }
-
-    if( me.powerButtonN.getBoolValue() and !me.power ) {
-      # power on, restart timer and start with FRQ display
-      me.et.restart();
-      me.flt.restart();
-      me.displayModeN.setIntValue( 0 );
-    }
-    me.power = me.powerButtonN.getValue();
-
-    settimer( func { me.update() }, 0.1 );
-  }
 };
 
 var kr87_0 = kr87.new( "/instrumentation/adf[0]" ).update();
 
 #setlistener("/sim/signals/fdm-initialized", func { timer_update() } );
-

--- a/Nasal/liveries.nas
+++ b/Nasal/liveries.nas
@@ -1,4 +1,2 @@
-
 # liveries =========================================================
 aircraft.livery.init("/Aircraft/c172p/Models/Liveries", "sim/model/livery/name", "sim/model/liverytail/name", "sim/model/liverywing/name", "sim/model/livery/index");
-

--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -5,29 +5,29 @@ var reset_all_damage = func
 {
     setprop("/engines/active-engine/killed", 0);
 
-	setprop(gears~"unit[0]/broken", 0);
-	setprop(gears~"unit[1]/broken", 0);
-	setprop(gears~"unit[2]/broken", 0);
-	setprop(contact~"unit[4]/z-position", 50);
-	setprop(contact~"unit[5]/z-position", 50);
-	setprop(contact~"unit[9]/z-position", 35);
-	setprop(contact~"unit[10]/z-position", 8);
-	setprop(contact~"unit[11]/z-position", 60);
-	setprop(contact~"unit[12]/z-position", 90);
-	setprop("/fdm/jsbsim/wing-damage/left-wing", 0);
-	setprop("/fdm/jsbsim/wing-damage/right-wing", 0);
-	setprop("/fdm/jsbsim/crash", 0);
-	setprop("/fdm/jsbsim/pontoon-damage/left-pontoon", 0);
-	setprop("/fdm/jsbsim/pontoon-damage/right-pontoon", 0);
+    setprop(gears~"unit[0]/broken", 0);
+    setprop(gears~"unit[1]/broken", 0);
+    setprop(gears~"unit[2]/broken", 0);
+    setprop(contact~"unit[4]/z-position", 50);
+    setprop(contact~"unit[5]/z-position", 50);
+    setprop(contact~"unit[9]/z-position", 35);
+    setprop(contact~"unit[10]/z-position", 8);
+    setprop(contact~"unit[11]/z-position", 60);
+    setprop(contact~"unit[12]/z-position", 90);
+    setprop("/fdm/jsbsim/wing-damage/left-wing", 0);
+    setprop("/fdm/jsbsim/wing-damage/right-wing", 0);
+    setprop("/fdm/jsbsim/crash", 0);
+    setprop("/fdm/jsbsim/pontoon-damage/left-pontoon", 0);
+    setprop("/fdm/jsbsim/pontoon-damage/right-pontoon", 0);
 
-	# Reset contacts
-	setprop(gears~"unit[0]/z-position", 0);
-	setprop(gears~"unit[1]/z-position", 0);
-	setprop(gears~"unit[2]/z-position", 0);
-	setprop(contact~"unit[6]/z-position", 0);
-	setprop(contact~"unit[7]/z-position", 0);
-	setprop(contact~"unit[8]/z-position", 0);
-	setprop(gears~"unit[19]/z-position", 0);
+    # Reset contacts
+    setprop(gears~"unit[0]/z-position", 0);
+    setprop(gears~"unit[1]/z-position", 0);
+    setprop(gears~"unit[2]/z-position", 0);
+    setprop(contact~"unit[6]/z-position", 0);
+    setprop(contact~"unit[7]/z-position", 0);
+    setprop(contact~"unit[8]/z-position", 0);
+    setprop(gears~"unit[19]/z-position", 0);
     setprop(gears~"unit[20]/z-position", 0);
     setprop(gears~"unit[21]/z-position", 0);
     setprop(gears~"unit[22]/z-position", 0);
@@ -42,48 +42,48 @@ var repair_damage = func {
 
 var nosegearbroke = func (bushkit)
 {
-	if (bushkit == 0)
-		setprop(contact~"unit[6]/z-position", -10);
-	elsif (bushkit == 1)
-		setprop(contact~"unit[6]/z-position", -18.5);
-	elsif (bushkit == 2)
-		setprop(contact~"unit[6]/z-position", -17.7);
+    if (bushkit == 0)
+        setprop(contact~"unit[6]/z-position", -10);
+    elsif (bushkit == 1)
+        setprop(contact~"unit[6]/z-position", -18.5);
+    elsif (bushkit == 2)
+        setprop(contact~"unit[6]/z-position", -17.7);
 
-	setprop(gears~"unit[0]/z-position", 0);
+    setprop(gears~"unit[0]/z-position", 0);
     killengine();
 }
 
 var leftgearbroke = func (bushkit)
 {
-	if (bushkit == 0)
-		setprop(contact~"unit[7]/z-position", -9.5);
-	elsif (bushkit == 1)
-		setprop(contact~"unit[7]/z-position", -14.5);
-	elsif (bushkit == 2)
-		setprop(contact~"unit[7]/z-position", -16);
-	elsif (bushkit == 5)
-		setprop(gears~"unit[24]/z-position", -14);
+    if (bushkit == 0)
+        setprop(contact~"unit[7]/z-position", -9.5);
+    elsif (bushkit == 1)
+        setprop(contact~"unit[7]/z-position", -14.5);
+    elsif (bushkit == 2)
+        setprop(contact~"unit[7]/z-position", -16);
+    elsif (bushkit == 5)
+        setprop(gears~"unit[24]/z-position", -14);
 
-	setprop(gears~"unit[1]/z-position", 0);
+    setprop(gears~"unit[1]/z-position", 0);
 }
 
 var rightgearbroke = func (bushkit)
 {
-	if (bushkit == 0)
-		setprop(contact~"unit[8]/z-position", -8);
-	elsif (bushkit == 1)
-		setprop(contact~"unit[8]/z-position", -15.5);
-	elsif (bushkit == 2)
-		setprop(contact~"unit[8]/z-position", -17.4);
-	elsif (bushkit == 5)
-		setprop(gears~"unit[25]/z-position", -16);
+    if (bushkit == 0)
+        setprop(contact~"unit[8]/z-position", -8);
+    elsif (bushkit == 1)
+        setprop(contact~"unit[8]/z-position", -15.5);
+    elsif (bushkit == 2)
+        setprop(contact~"unit[8]/z-position", -17.4);
+    elsif (bushkit == 5)
+        setprop(gears~"unit[25]/z-position", -16);
 
-	setprop(gears~"unit[2]/z-position", 0);
+    setprop(gears~"unit[2]/z-position", 0);
 }
 
 var bothwingcollapse = func
 {
-	setprop(contact~"unit[5]/z-position", -8);
+    setprop(contact~"unit[5]/z-position", -8);
 
     if (getprop("position/altitude-agl-m") < 10)
         killengine();
@@ -91,43 +91,43 @@ var bothwingcollapse = func
 
 var upsidedown = func
 {
-	setprop(contact~"unit[12]/z-position", 90);
+    setprop(contact~"unit[12]/z-position", 90);
 
-	if (getprop("/fdm/jsbsim/wing-damage/left-wing") == 1.0)
-		setprop(contact~"unit[4]/z-position", 40);
-	else
-		setprop(contact~"unit[4]/z-position", 50);
+    if (getprop("/fdm/jsbsim/wing-damage/left-wing") == 1.0)
+        setprop(contact~"unit[4]/z-position", 40);
+    else
+        setprop(contact~"unit[4]/z-position", 50);
 
-	if (getprop("/fdm/jsbsim/wing-damage/right-wing") == 1.0)
-		setprop(contact~"unit[5]/z-position", 40);
-	else
-		setprop(contact~"unit[5]/z-position", 50);
+    if (getprop("/fdm/jsbsim/wing-damage/right-wing") == 1.0)
+        setprop(contact~"unit[5]/z-position", 40);
+    else
+        setprop(contact~"unit[5]/z-position", 50);
 }
 
 var killengine = func
 {
-	setprop("/engines/active-engine/killed", 1);
+    setprop("/engines/active-engine/killed", 1);
 }
 
 var defaulttires = func
 {
-	setprop(gears~"unit[0]/z-position", -19.5);
-	setprop(gears~"unit[1]/z-position", -15.5);
-	setprop(gears~"unit[2]/z-position", -15.5);
+    setprop(gears~"unit[0]/z-position", -19.5);
+    setprop(gears~"unit[1]/z-position", -15.5);
+    setprop(gears~"unit[2]/z-position", -15.5);
 }
 
 var medbushtires = func
 {
-	setprop(gears~"unit[0]/z-position", -22);
-	setprop(gears~"unit[1]/z-position", -20);
-	setprop(gears~"unit[2]/z-position", -20);
+    setprop(gears~"unit[0]/z-position", -22);
+    setprop(gears~"unit[1]/z-position", -20);
+    setprop(gears~"unit[2]/z-position", -20);
 }
 
 var largebushtires = func
 {
-	setprop(gears~"unit[0]/z-position", -22);
-	setprop(gears~"unit[1]/z-position", -22);
-	setprop(gears~"unit[2]/z-position", -22);
+    setprop(gears~"unit[0]/z-position", -22);
+    setprop(gears~"unit[1]/z-position", -22);
+    setprop(gears~"unit[2]/z-position", -22);
 }
 
 var pontoons = func
@@ -137,10 +137,10 @@ var pontoons = func
 
 var amphibious = func
 {
-	setprop(gears~"unit[19]/z-position", -62);
-	setprop(gears~"unit[20]/z-position", -62);
-	setprop(gears~"unit[21]/z-position", -50.5);
-	setprop(gears~"unit[22]/z-position", -50.5);
+    setprop(gears~"unit[19]/z-position", -62);
+    setprop(gears~"unit[20]/z-position", -62);
+    setprop(gears~"unit[21]/z-position", -50.5);
+    setprop(gears~"unit[22]/z-position", -50.5);
 }
 
 var skis = func
@@ -162,15 +162,15 @@ var poll_surface = func
 
     # Use engine RPM and speed to control ground splash if on the water
     # and below 2 meter AGL
-	if (getprop("position/altitude-agl-m") < 2 and hydro_active_norm > 0) {
-	    var groundspeed_half_pc = 0.005 * getprop("velocities/groundspeed-kt");
+    if (getprop("position/altitude-agl-m") < 2 and hydro_active_norm > 0) {
+        var groundspeed_half_pc = 0.005 * getprop("velocities/groundspeed-kt");
         var engine_rpm_almost_nothing = 0.005 * 0.065 * engine_rpm;
 
-	    var splash_norm = std.max(engine_rpm_almost_nothing, groundspeed_half_pc);
-	    setprop("/environment/aircraft-effects/ground-splash-norm", splash_norm);
-	}
-	elsif (ground_splash_norm > 0)
-	    setprop("/environment/aircraft-effects/ground-splash-norm", ground_splash_norm - 0.005);
+        var splash_norm = std.max(engine_rpm_almost_nothing, groundspeed_half_pc);
+        setprop("/environment/aircraft-effects/ground-splash-norm", splash_norm);
+    }
+    elsif (ground_splash_norm > 0)
+        setprop("/environment/aircraft-effects/ground-splash-norm", ground_splash_norm - 0.005);
 
     setprop(contact~"unit[12]/z-position", !getprop(contact~"unit[12]/solid") ? 160 : 90);
     setprop(contact~"unit[4]/z-position", !getprop(contact~"unit[4]/solid") ? -10 : 50);

--- a/Nasal/tanks.nas
+++ b/Nasal/tanks.nas
@@ -3,10 +3,10 @@
 # /fdm/jsbsim/propulsion/tank[]/priority
 
 setlistener("consumables/fuel/tank[0]/selected", func(selected) {
-  setprop("/fdm/jsbsim/propulsion/tank[0]/priority", selected.getBoolValue() ? 1 : 0);
+    setprop("/fdm/jsbsim/propulsion/tank[0]/priority", selected.getBoolValue() ? 1 : 0);
 });
 
 setlistener("consumables/fuel/tank[1]/selected", func(selected) {
-  setprop("/fdm/jsbsim/propulsion/tank[1]/priority", selected.getBoolValue() ? 1 : 0);
+    setprop("/fdm/jsbsim/propulsion/tank[1]/priority", selected.getBoolValue() ? 1 : 0);
 });
 

--- a/Nasal/weather.nas
+++ b/Nasal/weather.nas
@@ -39,176 +39,176 @@ var weather_effects_loop = func {
     var surfacetempC = getprop("/environment/aircraft-effects/surfacetempC");
     var cabinairdewpointC = getprop("/environment/aircraft-effects/cabinairdewpointC");
 
-	############################################## frost/fog/heat/air
-	
-	dewpointC = getprop("/environment/dewpoint-degc");
-	airtempC = getprop("/environment/temperature-degc");
-	cabinairdewpointC = dewpointC;
-	cabinairset = getprop("/environment/aircraft-effects/cabin-air-set");
-	cabinheatset = getprop("/environment/aircraft-effects/cabin-heat-set");
-	
-	#debug
-	#tempmatch = getprop("/environment/aircraft-effects/debug-tempmatch-airtempC");
-	#if (tempmatch) surfacetempC = cabinairtempC = airtempC;
-	#end debug
+    ############################################## frost/fog/heat/air
 
-	#cabinheat only pushes heat into cabin if a cabinair is open.
-	#cabinair is the flow of air into cabin(it will contian heat if cabinheat is open),
-	#otherwise it is just outside airtemp
-	if (cabinheatset > 0) 
-	{
-		cabinairtempC += .04*(cabinheatset*cabinairset);
-		if (cabinairtempC > 32)
-		{
-			if (!getprop("/fdm/jsbsim/weather"))
-				gui.popupTip("Cabin temperature exceeding 90F/32C!");
-		}
-		#surfacetemp is slowely changed by cabinairtemp
-		if (surfacetempC < cabinairtempC)
-			surfacetempC += .03*(cabinheatset*cabinairset);
-		if (surfacetempC > cabinairtempC)
-			surfacetempC -= .03*(cabinheatset*cabinairset);
-	} 
-	else
-	if (cabinairset > 0)
-	{
-		#if no cabinheat then we incrementally adjust cabintemp with outside airtemp
-		if (cabinairtempC < airtempC)
-			cabinairtempC += .03*cabinairset;
-		if (cabinairtempC > airtempC) 
-			cabinairtempC -= .03*cabinairset;
-		if (surfacetempC < cabinairtempC)
-			surfacetempC += .02*cabinairset;
-		if (surfacetempC > cabinairtempC)
-			surfacetempC -= .02*cabinairset; 
-	} 
+    dewpointC = getprop("/environment/dewpoint-degc");
+    airtempC = getprop("/environment/temperature-degc");
+    cabinairdewpointC = dewpointC;
+    cabinairset = getprop("/environment/aircraft-effects/cabin-air-set");
+    cabinheatset = getprop("/environment/aircraft-effects/cabin-heat-set");
 
-	#regardless of whether or not vents are open we
-	#incremetally adjust cabintemp with outside airtemp
-	if (cabinairtempC < airtempC)
-		cabinairtempC += .01;
-	if (cabinairtempC > airtempC) 
-		cabinairtempC -= .01;
-	if (cabinairdewpointC < dewpointC)
-		cabinairdewpointC += .01;
-	if (cabinairdewpointC > dewpointC)
-		cabinairdewpointC -= .01;
-	if (surfacetempC < cabinairtempC)
-		surfacetempC += .01;
-	if (surfacetempC > cabinairtempC)
-		surfacetempC -= .01;
+    #debug
+    #tempmatch = getprop("/environment/aircraft-effects/debug-tempmatch-airtempC");
+    #if (tempmatch) surfacetempC = cabinairtempC = airtempC;
+    #end debug
 
-	#if cabinairtemp is less than dewpointtemp at startup we start out
-	#with fog. If it is also freezing we switch to frost.
-	#Otherwise we start calculating moisture level in the air
-	if (cabinairtempC <= cabinairdewpointC) 
-	{
-		if (start == 1) {
-			foglevel = 1;
-			if (cabinairtempC <= 0) 
-			{
-				frostlevel = 3;
-				foglevel = 0;
-			}
-			start = 0;
-		}
-		else 
-		if (surfacetempC <= cabinairdewpointC)
-			if (moisture < 1) moisture += .01;
-	}
-	else 
-	{
-		if (surfacetempC > cabinairdewpointC)
-			if (moisture > 0) moisture -= .01;
-		start = 0;
-	}
-	
-	#we can't get frost unless temp is freezing
-	#if it is not freezing then we get fog instead
-	if (cabinairtempC <= 0) 
-	{
-		if (!getprop("/fdm/jsbsim/weather"))
-			gui.popupTip("Cabin temperature falling below 32F/0C!");
-		frostlevel = moisture * 3;
-		if (foglevel > 0) foglevel -= moisture;
-		if (foglevel < 0) foglevel = 0;
-		if (frostlevel > 3) frostlevel = 3;
-	}
-	else
-	{
-		foglevel = moisture;
-		if (frostlevel > 0) frostlevel -= moisture;
-		if (frostlevel < 0) frostlevel = 0;
-		if (foglevel > 1) foglevel = 1;
-	}
-	
-	if (!getprop("/fdm/jsbsim/weather"))
-	{
-		setprop("/environment/aircraft-effects/frost-level", frostlevel);
-		setprop("/environment/aircraft-effects/fog-level", foglevel);
-		#added for flight recorder
-		if(!getprop("/sim/freeze/replay-state"))
-		{
-			setprop("/environment/aircraft-effects/cabinairtempC", cabinairtempC);
-			setprop("/environment/aircraft-effects/surfacetempC", surfacetempC);
-			setprop("/environment/aircraft-effects/cabinairdewpointC", cabinairdewpointC);
-		}
-	}
-	else
-	{
-		setprop("/environment/aircraft-effects/frost-level", 0);
-		setprop("/environment/aircraft-effects/fog-level", 0);
-		#added for flight recorder
-		if(!getprop("/sim/freeze/replay-state"))
-		{
-			setprop("/environment/aircraft-effects/cabinairtempC", getprop("/environment/temperature-degc"));
-			setprop("/environment/aircraft-effects/surfacetempC", getprop("/environment/temperature-degc"));
-			setprop("/environment/aircraft-effects/cabinairdewpointC", getprop("/environment/dewpoint-degc"));
-		}
-	}
+    #cabinheat only pushes heat into cabin if a cabinair is open.
+    #cabinair is the flow of air into cabin(it will contian heat if cabinheat is open),
+    #otherwise it is just outside airtemp
+    if (cabinheatset > 0) 
+    {
+        cabinairtempC += .04*(cabinheatset*cabinairset);
+        if (cabinairtempC > 32)
+        {
+            if (!getprop("/fdm/jsbsim/weather"))
+                gui.popupTip("Cabin temperature exceeding 90F/32C!");
+        }
+        #surfacetemp is slowely changed by cabinairtemp
+        if (surfacetempC < cabinairtempC)
+            surfacetempC += .03*(cabinheatset*cabinairset);
+        if (surfacetempC > cabinairtempC)
+            surfacetempC -= .03*(cabinheatset*cabinairset);
+    } 
+    else
+    if (cabinairset > 0)
+    {
+        #if no cabinheat then we incrementally adjust cabintemp with outside airtemp
+        if (cabinairtempC < airtempC)
+            cabinairtempC += .03*cabinairset;
+        if (cabinairtempC > airtempC) 
+            cabinairtempC -= .03*cabinairset;
+        if (surfacetempC < cabinairtempC)
+            surfacetempC += .02*cabinairset;
+        if (surfacetempC > cabinairtempC)
+            surfacetempC -= .02*cabinairset; 
+    } 
 
-	#debug
-	#if (cabinairtempC > 0)
-	#{
-	#	print("NO ICE, TOO WARM cabinairtempC > 0");
-	#} else print("ICE POSSIBLE, CABIN FREEZING cabinairtempC <= 0");
-	#if (airtempC > dewpointC) 
-	#{
-	#	print("NO OUTSIDE DEW airtempC > dewpointC");
-	#} else
-	#if (airtempC <= dewpointC) 
-	#{
-	#	print("OUTSIDE DEW ABLE airtempC <= dewpointC");
-	#	if (cabinairtempC < 0)
-	#	{
-	#		print("ICE ABLE, OUTSIDE DEW cabinairtempC < 0");
-	#	}
-	#} 
-	#if (cabinairtempC > cabinairdewpointC)
-	#{
-	#	print("NO INSIDE DEW cabinairtempC > cabinairdewpointC");
-	#} else
-	#if (cabinairtempC <= cabinairdewpointC)
-	#{
-	#	print("INSIDE DEW FORMING cabinairtempC <= cabinairdewpointC");
-	#	if (cabinairtempC <= 0)
-	#	{
-	#		if (surfacetempC <= 0)	
-	#			print("ICE BUILDING, CABIN DEW AND SUFACE FREEZING");
-	#		else
-	#			print("ICE ABLE CABIN DEW, SURFACE NOT FREEZING surfacetempC > 0");
-	#	}
-	#}
-	#print("moisture="~moisture);
-	#print("airtempC="~airtempC);
-	#print("dewpointC="~dewpointC);
-	#print("cabinheatset="~cabinheatset);
-	#print("cabinairset="~cabinairset);
-	#print("surfacetempC="~surfacetempC);
-	#print("cabinairtempC="~cabinairtempC);
-	#print("cabinairdewpointC="~cabinairdewpointC);
-	#print("foglevel="~foglevel);
-	#print("frostlevel="~frostlevel);
-	#end debug
-	
+    #regardless of whether or not vents are open we
+    #incremetally adjust cabintemp with outside airtemp
+    if (cabinairtempC < airtempC)
+        cabinairtempC += .01;
+    if (cabinairtempC > airtempC) 
+        cabinairtempC -= .01;
+    if (cabinairdewpointC < dewpointC)
+        cabinairdewpointC += .01;
+    if (cabinairdewpointC > dewpointC)
+        cabinairdewpointC -= .01;
+    if (surfacetempC < cabinairtempC)
+        surfacetempC += .01;
+    if (surfacetempC > cabinairtempC)
+        surfacetempC -= .01;
+
+    #if cabinairtemp is less than dewpointtemp at startup we start out
+    #with fog. If it is also freezing we switch to frost.
+    #Otherwise we start calculating moisture level in the air
+    if (cabinairtempC <= cabinairdewpointC) 
+    {
+        if (start == 1) {
+            foglevel = 1;
+            if (cabinairtempC <= 0) 
+            {
+                frostlevel = 3;
+                foglevel = 0;
+            }
+            start = 0;
+        }
+        else 
+        if (surfacetempC <= cabinairdewpointC)
+            if (moisture < 1) moisture += .01;
+    }
+    else 
+    {
+        if (surfacetempC > cabinairdewpointC)
+            if (moisture > 0) moisture -= .01;
+        start = 0;
+    }
+
+    #we can't get frost unless temp is freezing
+    #if it is not freezing then we get fog instead
+    if (cabinairtempC <= 0) 
+    {
+        if (!getprop("/fdm/jsbsim/weather"))
+            gui.popupTip("Cabin temperature falling below 32F/0C!");
+        frostlevel = moisture * 3;
+        if (foglevel > 0) foglevel -= moisture;
+        if (foglevel < 0) foglevel = 0;
+        if (frostlevel > 3) frostlevel = 3;
+    }
+    else
+    {
+        foglevel = moisture;
+        if (frostlevel > 0) frostlevel -= moisture;
+        if (frostlevel < 0) frostlevel = 0;
+        if (foglevel > 1) foglevel = 1;
+    }
+
+    if (!getprop("/fdm/jsbsim/weather"))
+    {
+        setprop("/environment/aircraft-effects/frost-level", frostlevel);
+        setprop("/environment/aircraft-effects/fog-level", foglevel);
+        #added for flight recorder
+        if(!getprop("/sim/freeze/replay-state"))
+        {
+            setprop("/environment/aircraft-effects/cabinairtempC", cabinairtempC);
+            setprop("/environment/aircraft-effects/surfacetempC", surfacetempC);
+            setprop("/environment/aircraft-effects/cabinairdewpointC", cabinairdewpointC);
+        }
+    }
+    else
+    {
+        setprop("/environment/aircraft-effects/frost-level", 0);
+        setprop("/environment/aircraft-effects/fog-level", 0);
+        #added for flight recorder
+        if(!getprop("/sim/freeze/replay-state"))
+        {
+            setprop("/environment/aircraft-effects/cabinairtempC", getprop("/environment/temperature-degc"));
+            setprop("/environment/aircraft-effects/surfacetempC", getprop("/environment/temperature-degc"));
+            setprop("/environment/aircraft-effects/cabinairdewpointC", getprop("/environment/dewpoint-degc"));
+        }
+    }
+
+    #debug
+    #if (cabinairtempC > 0)
+    #{
+    #    print("NO ICE, TOO WARM cabinairtempC > 0");
+    #} else print("ICE POSSIBLE, CABIN FREEZING cabinairtempC <= 0");
+    #if (airtempC > dewpointC) 
+    #{
+    #    print("NO OUTSIDE DEW airtempC > dewpointC");
+    #} else
+    #if (airtempC <= dewpointC) 
+    #{
+    #    print("OUTSIDE DEW ABLE airtempC <= dewpointC");
+    #    if (cabinairtempC < 0)
+    #    {
+    #        print("ICE ABLE, OUTSIDE DEW cabinairtempC < 0");
+    #    }
+    #} 
+    #if (cabinairtempC > cabinairdewpointC)
+    #{
+    #    print("NO INSIDE DEW cabinairtempC > cabinairdewpointC");
+    #} else
+    #if (cabinairtempC <= cabinairdewpointC)
+    #{
+    #    print("INSIDE DEW FORMING cabinairtempC <= cabinairdewpointC");
+    #    if (cabinairtempC <= 0)
+    #    {
+    #        if (surfacetempC <= 0)    
+    #            print("ICE BUILDING, CABIN DEW AND SUFACE FREEZING");
+    #        else
+    #            print("ICE ABLE CABIN DEW, SURFACE NOT FREEZING surfacetempC > 0");
+    #    }
+    #}
+    #print("moisture="~moisture);
+    #print("airtempC="~airtempC);
+    #print("dewpointC="~dewpointC);
+    #print("cabinheatset="~cabinheatset);
+    #print("cabinairset="~cabinairset);
+    #print("surfacetempC="~surfacetempC);
+    #print("cabinairtempC="~cabinairtempC);
+    #print("cabinairdewpointC="~cabinairdewpointC);
+    #print("foglevel="~foglevel);
+    #print("frostlevel="~frostlevel);
+    #end debug
+
 }

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -160,7 +160,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
                 <tiedownR type="bool">false</tiedownR>
                 
                 <!-- Parking brakes -->
-                <brake-parking type="bool">false</brake-parking>
+                <brake-parking type="bool">true</brake-parking>
 
             </c172p>
 
@@ -442,7 +442,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <gear>
             <water-rudder type="bool">0</water-rudder>
             <water-rudder-down type="double">0</water-rudder-down>
-            <brake-parking type="bool">false</brake-parking>
+            <brake-parking type="bool">true</brake-parking>
         </gear>
     </controls>
 

--- a/gui/dialogs/c172p-baggage-weight.xml
+++ b/gui/dialogs/c172p-baggage-weight.xml
@@ -29,41 +29,68 @@
     </group>
 
     <hrule/>
-        <group>
+    
+    <group>
         <layout>vbox</layout>
         <padding>6</padding>
-            <group>
-                <layout>hbox</layout>
-                <text>
-                    <label>Baggage Weight:</label>
-                    <halign>left</halign>
-                </text>
-                <slider>
+        <empty><stretch>true</stretch></empty>
+        <group>
+            <layout>hbox</layout>
+            <text>
+                <label>Baggage Weight:</label>
+                <halign>left</halign>
+            </text>
+            <slider>
+                <name>c172p-baggage-weight-slider</name>
+                <min>0</min>
+                <max>150.0</max>
+                <live>true</live>
+                <enable>
+                    <less-than>
+                        <property>velocities/groundspeed-kt</property>
+                        <value>1.0</value>
+                    </less-than>
+                </enable>
+                <property>/payload/weight[4]/weight-lb</property>
+                <binding>
+                    <command>dialog-apply</command>
                     <name>c172p-baggage-weight-slider</name>
-                    <min>0</min>
-                    <max>150.0</max>
-                    <live>true</live>
-                    <property>/payload/weight[4]/weight-lb</property>
-                    <binding>
-                        <command>dialog-apply</command>
-                        <name>c172p-baggage-weight-slider</name>
-                    </binding>
-                </slider>
-                <text>
-                    <label>123</label>
-                    <halign>left</halign>
-                    <format>%.0f</format>
-                    <live>true</live>
-                    <property>/payload/weight[4]/weight-lb</property>
-                </text>
-                <text>
-                    <label>pounds</label>
-                    <halign>left</halign>
-                </text>
-            </group>
+                </binding>
+            </slider>
+            <text>
+                <label>123</label>
+                <halign>left</halign>
+                <format>%.0f</format>
+                <live>true</live>
+                <property>/payload/weight[4]/weight-lb</property>
+            </text>
+            <text>
+                <label>pounds</label>
+                <halign>left</halign>
+            </text>
         </group>
-    <hrule/>
+    </group>
 
+    <group>
+        <layout>hbox</layout>
+        <text>
+            <visible>
+                <greater-than-equals>
+                    <property>velocities/groundspeed-kt</property>
+                    <value>1.0</value>
+                </greater-than-equals>
+            </visible>
+            <color>
+                <red>0.9</red>
+                <green>0.1</green>
+                <blue>0.1</blue>
+            </color>
+            <label>Dialog disabled when in movement</label>
+        </text>
+    </group>
+        
+    <hrule/>
+    
     <group>
         <layout>hbox</layout>
         <default-padding>6</default-padding>

--- a/gui/dialogs/c172p-left-fuel-sample.xml
+++ b/gui/dialogs/c172p-left-fuel-sample.xml
@@ -115,6 +115,24 @@
             </binding>
         </button>
     </group>
+    
+    <group>
+        <layout>hbox</layout>
+        <text>
+            <visible>
+                <greater-than-equals>
+                    <property>velocities/groundspeed-kt</property>
+                    <value>1.0</value>
+                </greater-than-equals>
+            </visible>
+            <color>
+                <red>0.9</red>
+                <green>0.1</green>
+                <blue>0.1</blue>
+            </color>
+            <label>Dialog disabled when in movement</label>
+        </text>
+    </group>
 
     <hrule/>
     

--- a/gui/dialogs/c172p-left-fuel.xml
+++ b/gui/dialogs/c172p-left-fuel.xml
@@ -29,62 +29,88 @@
     </group>
 
     <hrule/>
+    
+    <group>
+        <layout>vbox</layout>
+        <padding>6</padding>
         <group>
-            <layout>vbox</layout>
-            <padding>6</padding>
-            <group>
-                <layout>hbox</layout>
-                <text>
-                    <label>Left Fuel Tank:</label>
-                    <halign>left</halign>
-                </text>
-                <slider>
+            <layout>hbox</layout>
+            <text>
+                <label>Left Fuel Tank:</label>
+                <halign>left</halign>
+            </text>
+            <slider>
+                <name>c172p-left-fuel-slider</name>
+                <min>0</min>
+                <max>28.0</max>
+                <live>true</live>
+                <enable>
+                    <less-than>
+                        <property>velocities/groundspeed-kt</property>
+                        <value>1.0</value>
+                    </less-than>
+                </enable>
+                <property>/consumables/fuel/tank[0]/level-gal_us</property>
+                <binding>
+                    <command>dialog-apply</command>
                     <name>c172p-left-fuel-slider</name>
-                    <min>0</min>
-                    <max>28.0</max>
-                    <live>true</live>
-                    <property>/consumables/fuel/tank[0]/level-gal_us</property>
-                    <binding>
-                        <command>dialog-apply</command>
-                        <name>c172p-left-fuel-slider</name>
-                    </binding>
-                </slider>
+                </binding>
+            </slider>
+            <group>
+                <layout>vbox</layout>
+                <padding>6</padding>
                 <group>
-                    <layout>vbox</layout>
+                    <layout>hbox</layout>
                     <padding>6</padding>
-                    <group>
-                        <layout>hbox</layout>
-                        <padding>6</padding>
-                        <text>
-                            <label>1234</label>
-                            <halign>left</halign>
-                            <format>%.2f</format>
-                            <live>true</live>
-                            <property>/consumables/fuel/tank[0]/level-gal_us</property>
-                        </text>
-                        <text>
-                            <label>gallons</label>
-                            <halign>left</halign>
-                        </text>
-                    </group>
-                    <group>
-                        <layout>hbox</layout>
-                        <padding>6</padding>
-                        <text>
-                            <label>1234</label>
-                            <halign>left</halign>
-                            <format>%.1f</format>
-                            <live>true</live>
-                            <property>/consumables/fuel/tank[0]/level-lbs</property>
-                        </text>
-                        <text>
-                            <label>pounds</label>
-                            <halign>left</halign>
-                        </text>
-                    </group>
+                    <text>
+                        <label>1234</label>
+                        <halign>left</halign>
+                        <format>%.2f</format>
+                        <live>true</live>
+                        <property>/consumables/fuel/tank[0]/level-gal_us</property>
+                    </text>
+                    <text>
+                        <label>gallons</label>
+                        <halign>left</halign>
+                    </text>
+                </group>
+                <group>
+                    <layout>hbox</layout>
+                    <padding>6</padding>
+                    <text>
+                        <label>1234</label>
+                        <halign>left</halign>
+                        <format>%.1f</format>
+                        <live>true</live>
+                        <property>/consumables/fuel/tank[0]/level-lbs</property>
+                    </text>
+                    <text>
+                        <label>pounds</label>
+                        <halign>left</halign>
+                    </text>
                 </group>
             </group>
         </group>
+    </group>
+    
+    <group>
+        <layout>hbox</layout>
+        <text>
+            <visible>
+                <greater-than-equals>
+                    <property>velocities/groundspeed-kt</property>
+                    <value>1.0</value>
+                </greater-than-equals>
+            </visible>
+            <color>
+                <red>0.9</red>
+                <green>0.1</green>
+                <blue>0.1</blue>
+            </color>
+            <label>Dialog disabled when in movement</label>
+        </text>
+    </group>
+        
     <hrule/>
 
     <group>

--- a/gui/dialogs/c172p-oil-160.xml
+++ b/gui/dialogs/c172p-oil-160.xml
@@ -29,104 +29,125 @@
     </group>
 
     <hrule/>
+    
+    <group>
+        <layout>vbox</layout>
+        <padding>6</padding>
+        <empty><stretch>true</stretch></empty>
         <group>
-            <layout>vbox</layout>
-            <padding>6</padding>
+            <layout>hbox</layout>
+            <text>
+                <label>Oil Level:</label>
+                <halign>left</halign>
+            </text>
+            <slider>                
+                <name>c172p-oil-slider-160</name>
+                <min>0</min>
+                <max>7.0</max>
+                <live>true</live>
+                <enable>
+                    <less-than>
+                        <property>velocities/groundspeed-kt</property>
+                        <value>1.0</value>
+                    </less-than>
+                </enable>
+                <property>/engines/active-engine/oil-level</property>
+                <binding>
+                    <command>dialog-apply</command>
+                    <name>c172p-oil-slider-160</name>
+                </binding>
+            </slider>
             <group>
                 <layout>hbox</layout>
+                <padding>6</padding>
                 <text>
-                    <label>Oil Level:</label>
+                    <label>123</label>
+                    <halign>left</halign>
+                    <format>%.2f</format>
+                    <live>true</live>
+                    <property>/engines/active-engine/oil-level</property>
+                </text>
+                <text>
+                    <label>quarts</label>
                     <halign>left</halign>
                 </text>
-                <slider>                
-                    <name>c172p-oil-slider-160</name>
-                    <min>0</min>
-                    <max>7.0</max>
-                    <live>true</live>
-                    <enable>
-                        <less-than>
-                            <property>velocities/groundspeed-kt</property>
-                            <value>1.0</value>
-                        </less-than>
-                    </enable>
-                    <property>/engines/active-engine/oil-level</property>
-                    <binding>
-                        <command>dialog-apply</command>
-                        <name>c172p-oil-slider-160</name>
-                    </binding>
-                </slider>
-                <group>
-                    <layout>hbox</layout>
-                    <padding>6</padding>
-                    <text>
-                        <label>123</label>
-                        <halign>left</halign>
-                        <format>%.2f</format>
-                        <live>true</live>
-                        <property>/engines/active-engine/oil-level</property>
-                    </text>
-                    <text>
-                        <label>quarts</label>
-                        <halign>left</halign>
-                    </text>
-                </group>
             </group>
         </group>
+    </group>
+    
+    <group>
+        <layout>hbox</layout>
+        <text>
+            <visible>
+                <greater-than-equals>
+                    <property>velocities/groundspeed-kt</property>
+                    <value>1.0</value>
+                </greater-than-equals>
+            </visible>
+            <color>
+                <red>0.9</red>
+                <green>0.1</green>
+                <blue>0.1</blue>
+            </color>
+            <label>Dialog disabled when in movement</label>
+        </text>
+    </group>
     
     <hrule/>
     
-        <group>
-            <layout>table</layout>
-            <text>
-                <row>0</row>
-                <col>0</col>
-                <visible>
-                    <greater-than>
-                        <property>/engines/active-engine/oil-level</property>
-                        <value>6.0</value>
-                    </greater-than>
-                </visible>
-                <label>Good oil level</label>
-            </text>
-            <text>
-                <row>0</row>
-                <col>0</col>
-                <visible>
-                    <and>
-                        <less-than-equals>
-                            <property>/engines/active-engine/oil-level</property>
-                            <value>6.0</value>
-                        </less-than-equals>
-                        <greater-than>
-                            <property>/engines/active-engine/oil-level</property>
-                            <value>5.0</value>
-                        </greater-than>
-                    </and>
-                </visible>
-                <color>
-                    <red>0.9</red>
-                    <green>0.74</green>
-                    <blue>0.23</blue>
-                </color>
-                <label>Low oil level</label>
-            </text>
-            <text>
-                <row>0</row>
-                <col>0</col>
-                <visible>
+    <group>
+        <layout>table</layout>
+        <text>
+            <row>0</row>
+            <col>0</col>
+            <visible>
+                <greater-than>
+                    <property>/engines/active-engine/oil-level</property>
+                    <value>6.0</value>
+                </greater-than>
+            </visible>
+            <label>Good oil level</label>
+        </text>
+        <text>
+            <row>0</row>
+            <col>0</col>
+            <visible>
+                <and>
                     <less-than-equals>
                         <property>/engines/active-engine/oil-level</property>
-                        <value>5.0</value>
+                        <value>6.0</value>
                     </less-than-equals>
-                </visible>
-                <color>
-                    <red>0.95</red>
-                    <green>0.0</green>
-                    <blue>0.0</blue>
-                </color>
-                <label>Critical oil level!</label>
-            </text>
-        </group>
+                    <greater-than>
+                        <property>/engines/active-engine/oil-level</property>
+                        <value>5.0</value>
+                    </greater-than>
+                </and>
+            </visible>
+            <color>
+                <red>0.9</red>
+                <green>0.74</green>
+                <blue>0.23</blue>
+            </color>
+            <label>Low oil level</label>
+        </text>
+        <text>
+            <row>0</row>
+            <col>0</col>
+            <visible>
+                <less-than-equals>
+                    <property>/engines/active-engine/oil-level</property>
+                    <value>5.0</value>
+                </less-than-equals>
+            </visible>
+            <color>
+                <red>0.95</red>
+                <green>0.0</green>
+                <blue>0.0</blue>
+            </color>
+            <label>Critical oil level!</label>
+        </text>
+    </group>
+        
     <hrule/>
 
     <group>

--- a/gui/dialogs/c172p-oil-180.xml
+++ b/gui/dialogs/c172p-oil-180.xml
@@ -29,104 +29,125 @@
     </group>
 
     <hrule/>
+
+    <group>
+        <layout>vbox</layout>
+        <padding>6</padding>
+        <empty><stretch>true</stretch></empty>
         <group>
-            <layout>vbox</layout>
-            <padding>6</padding>
+            <layout>hbox</layout>
+            <text>
+                <label>Oil Level:</label>
+                <halign>left</halign>
+            </text>
+            <slider>
+                <name>c172p-oil-slider-180</name>
+                <min>0</min>
+                <max>8.0</max>
+                <live>true</live>
+                <enable>
+                    <less-than>
+                        <property>velocities/groundspeed-kt</property>
+                        <value>1.0</value>
+                    </less-than>
+                </enable>
+                <property>/engines/active-engine/oil-level</property>
+                <binding>
+                    <command>dialog-apply</command>
+                    <name>c172p-oil-slider-180</name>
+                </binding>
+            </slider>
             <group>
                 <layout>hbox</layout>
+                <padding>6</padding>
                 <text>
-                    <label>Oil Level:</label>
+                    <label>123</label>
+                    <halign>left</halign>
+                    <format>%.2f</format>
+                    <live>true</live>
+                    <property>/engines/active-engine/oil-level</property>
+                </text>
+                <text>
+                    <label>quarts</label>
                     <halign>left</halign>
                 </text>
-                <slider>
-                    <name>c172p-oil-slider-180</name>
-                    <min>0</min>
-                    <max>8.0</max>
-                    <live>true</live>
-                    <enable>
-                        <less-than>
-                            <property>velocities/groundspeed-kt</property>
-                            <value>1.0</value>
-                        </less-than>
-                    </enable>
-                    <property>/engines/active-engine/oil-level</property>
-                    <binding>
-                        <command>dialog-apply</command>
-                        <name>c172p-oil-slider-180</name>
-                    </binding>
-                </slider>
-                <group>
-                    <layout>hbox</layout>
-                    <padding>6</padding>
-                    <text>
-                        <label>123</label>
-                        <halign>left</halign>
-                        <format>%.2f</format>
-                        <live>true</live>
-                        <property>/engines/active-engine/oil-level</property>
-                    </text>
-                    <text>
-                        <label>quarts</label>
-                        <halign>left</halign>
-                    </text>
-                </group>
             </group>
         </group>
+    </group>
+    
+    <group>
+        <layout>hbox</layout>
+        <text>
+            <visible>
+                <greater-than-equals>
+                    <property>velocities/groundspeed-kt</property>
+                    <value>1.0</value>
+                </greater-than-equals>
+            </visible>
+            <color>
+                <red>0.9</red>
+                <green>0.1</green>
+                <blue>0.1</blue>
+            </color>
+            <label>Dialog disabled when in movement</label>
+        </text>
+    </group>
     
     <hrule/>
-    
-        <group>
-            <layout>table</layout>
-            <text>
-                <row>0</row>
-                <col>0</col>
-                <visible>
-                    <greater-than>
-                        <property>/engines/active-engine/oil-level</property>
-                        <value>6.0</value>
-                    </greater-than>
-                </visible>
-                <label>Good oil level</label>
-            </text>
-            <text>
-                <row>0</row>
-                <col>0</col>
-                <visible>
-                    <and>
-                        <less-than-equals>
-                            <property>/engines/active-engine/oil-level</property>
-                            <value>6.0</value>
-                        </less-than-equals>
-                        <greater-than>
-                            <property>/engines/active-engine/oil-level</property>
-                            <value>5.0</value>
-                        </greater-than>
-                    </and>
-                </visible>
-                <color>
-                    <red>0.9</red>
-                    <green>0.74</green>
-                    <blue>0.23</blue>
-                </color>
-                <label>Low oil level</label>
-            </text>
-            <text>
-                <row>0</row>
-                <col>0</col>
-                <visible>
+
+    <group>
+        <layout>table</layout>
+        <text>
+            <row>0</row>
+            <col>0</col>
+            <visible>
+                <greater-than>
+                    <property>/engines/active-engine/oil-level</property>
+                    <value>6.0</value>
+                </greater-than>
+            </visible>
+            <label>Good oil level</label>
+        </text>
+        <text>
+            <row>0</row>
+            <col>0</col>
+            <visible>
+                <and>
                     <less-than-equals>
                         <property>/engines/active-engine/oil-level</property>
-                        <value>5.0</value>
+                        <value>6.0</value>
                     </less-than-equals>
-                </visible>
-                <color>
-                    <red>0.95</red>
-                    <green>0.0</green>
-                    <blue>0.0</blue>
-                </color>
-                <label>Critical oil level!</label>
-            </text>
-        </group>
+                    <greater-than>
+                        <property>/engines/active-engine/oil-level</property>
+                        <value>5.0</value>
+                    </greater-than>
+                </and>
+            </visible>
+            <color>
+                <red>0.9</red>
+                <green>0.74</green>
+                <blue>0.23</blue>
+            </color>
+            <label>Low oil level</label>
+        </text>
+        <text>
+            <row>0</row>
+            <col>0</col>
+            <visible>
+                <less-than-equals>
+                    <property>/engines/active-engine/oil-level</property>
+                    <value>5.0</value>
+                </less-than-equals>
+            </visible>
+            <color>
+                <red>0.95</red>
+                <green>0.0</green>
+                <blue>0.0</blue>
+            </color>
+            <label>Critical oil level!</label>
+        </text>
+    </group>
+    
     <hrule/>
 
     <group>

--- a/gui/dialogs/c172p-right-fuel-sample.xml
+++ b/gui/dialogs/c172p-right-fuel-sample.xml
@@ -115,6 +115,24 @@
             </binding>
         </button>
     </group>
+    
+    <group>
+        <layout>hbox</layout>
+        <text>
+            <visible>
+                <greater-than-equals>
+                    <property>velocities/groundspeed-kt</property>
+                    <value>1.0</value>
+                </greater-than-equals>
+            </visible>
+            <color>
+                <red>0.9</red>
+                <green>0.1</green>
+                <blue>0.1</blue>
+            </color>
+            <label>Dialog disabled when in movement</label>
+        </text>
+    </group>
 
     <hrule/>
     

--- a/gui/dialogs/c172p-right-fuel.xml
+++ b/gui/dialogs/c172p-right-fuel.xml
@@ -29,62 +29,88 @@
     </group>
 
     <hrule/>
+    
+    <group>
+        <layout>vbox</layout>
+        <padding>6</padding>
         <group>
-            <layout>vbox</layout>
-            <padding>6</padding>
-            <group>
-                <layout>hbox</layout>
-                <text>
-                    <label>Right Fuel Tank:</label>
-                    <halign>left</halign>
-                </text>
-                <slider>
+            <layout>hbox</layout>
+            <text>
+                <label>Right Fuel Tank:</label>
+                <halign>left</halign>
+            </text>
+            <slider>
+                <name>c172p-right-fuel-slider</name>
+                <min>0</min>
+                <max>28.0</max>
+                <live>true</live>
+                <enable>
+                    <less-than>
+                        <property>velocities/groundspeed-kt</property>
+                        <value>1.0</value>
+                    </less-than>
+                </enable>
+                <property>/consumables/fuel/tank[1]/level-gal_us</property>
+                <binding>
+                    <command>dialog-apply</command>
                     <name>c172p-right-fuel-slider</name>
-                    <min>0</min>
-                    <max>28.0</max>
-                    <live>true</live>
-                    <property>/consumables/fuel/tank[1]/level-gal_us</property>
-                    <binding>
-                        <command>dialog-apply</command>
-                        <name>c172p-right-fuel-slider</name>
-                    </binding>
-                </slider>
+                </binding>
+            </slider>
+            <group>
+                <layout>vbox</layout>
+                <padding>6</padding>
                 <group>
-                    <layout>vbox</layout>
+                    <layout>hbox</layout>
                     <padding>6</padding>
-                    <group>
-                        <layout>hbox</layout>
-                        <padding>6</padding>
-                        <text>
-                            <label>1234</label>
-                            <halign>left</halign>
-                            <format>%.2f</format>
-                            <live>true</live>
-                            <property>/consumables/fuel/tank[1]/level-gal_us</property>
-                        </text>
-                        <text>
-                            <label>gallons</label>
-                            <halign>left</halign>
-                        </text>
-                    </group>
-                    <group>
-                        <layout>hbox</layout>
-                        <padding>6</padding>
-                        <text>
-                            <label>1234</label>
-                            <halign>left</halign>
-                            <format>%.1f</format>
-                            <live>true</live>
-                            <property>/consumables/fuel/tank[1]/level-lbs</property>
-                        </text>
-                        <text>
-                            <label>pounds</label>
-                            <halign>left</halign>
-                        </text>
-                    </group>
+                    <text>
+                        <label>1234</label>
+                        <halign>left</halign>
+                        <format>%.2f</format>
+                        <live>true</live>
+                        <property>/consumables/fuel/tank[1]/level-gal_us</property>
+                    </text>
+                    <text>
+                        <label>gallons</label>
+                        <halign>left</halign>
+                    </text>
+                </group>
+                <group>
+                    <layout>hbox</layout>
+                    <padding>6</padding>
+                    <text>
+                        <label>1234</label>
+                        <halign>left</halign>
+                        <format>%.1f</format>
+                        <live>true</live>
+                        <property>/consumables/fuel/tank[1]/level-lbs</property>
+                    </text>
+                    <text>
+                        <label>pounds</label>
+                        <halign>left</halign>
+                    </text>
                 </group>
             </group>
         </group>
+    </group>
+        
+    <group>
+        <layout>hbox</layout>
+        <text>
+            <visible>
+                <greater-than-equals>
+                    <property>velocities/groundspeed-kt</property>
+                    <value>1.0</value>
+                </greater-than-equals>
+            </visible>
+            <color>
+                <red>0.9</red>
+                <green>0.1</green>
+                <blue>0.1</blue>
+            </color>
+            <label>Dialog disabled when in movement</label>
+        </text>
+    </group>
+        
     <hrule/>
 
     <group>


### PR DESCRIPTION
- all dialogs that are opened via pick animations (oil quantity, baggage weight, both fuel tanks and fuel sumps) are disabled if the aircraft is in movement
- added warning message when dialogs are disabled (as not to baffle people of why they can't click anywhere)
- fixed some indentation
- parking brake default state set to ON
- autostart sets parking brake automatically to OFF and also removes chocks, tie-downs and pitot tube cover, sets oil-level to a good value and removes any contamination from both fuel tank

Closes #543 and #548