### PR TITLE
Tie amphibious landing gear panel to alternator and battery switches.

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -257,6 +257,11 @@
             <mixture>/controls/engines/current-engine/mixture</mixture>
             <carb-heat>/controls/engines/current-engine/carb-heat</carb-heat>
         </controls>
+        <cockpit>
+            <electrical>
+                <gear-amphibious>/sim/model/c172p/lighting/amphibious</gear-amphibious>
+            </electrical>
+        </cockpit>
     </params>
 
     <!-- exterior effects -->
@@ -6963,6 +6968,7 @@
                    <property alias="/params/bushkit/property"/>
                    <value>4</value>
                 </equals>
+                <property alias="/params/cockpit/electrical/gear-amphibious"/>
             </and>
         </condition>
     </animation>
@@ -6980,6 +6986,7 @@
                    <property alias="/params/bushkit/property"/>
                    <value>4</value>
                 </equals>
+                <property alias="/params/cockpit/electrical/gear-amphibious"/>
             </and>
         </condition>
     </animation>
@@ -6997,6 +7004,7 @@
                    <property alias="/params/bushkit/property"/>
                    <value>4</value>
                 </equals>
+                <property alias="/params/cockpit/electrical/gear-amphibious"/>
             </and>
         </condition>
     </animation>
@@ -7014,6 +7022,7 @@
                    <property alias="/params/bushkit/property"/>
                    <value>4</value>
                 </equals>
+                <property alias="/params/cockpit/electrical/gear-amphibious"/>
             </and>
         </condition>
     </animation>
@@ -7032,6 +7041,7 @@
                    <property alias="/params/bushkit/property"/>
                    <value>4</value>
                 </equals>
+                <property alias="/params/cockpit/electrical/gear-amphibious"/>
             </and>
         </condition>
     </animation>
@@ -7049,6 +7059,7 @@
                    <property alias="/params/bushkit/property"/>
                    <value>4</value>
                 </equals>
+                <property alias="/params/cockpit/electrical/gear-amphibious"/>
             </and>
         </condition>
     </animation>
@@ -7066,6 +7077,7 @@
                    <property alias="/params/bushkit/property"/>
                    <value>4</value>
                 </equals>
+                <property alias="/params/cockpit/electrical/gear-amphibious"/>
             </and>
         </condition>
     </animation>
@@ -7083,6 +7095,7 @@
                    <property alias="/params/bushkit/property"/>
                    <value>4</value>
                 </equals>
+                <property alias="/params/cockpit/electrical/gear-amphibious"/>
             </and>
         </condition>
     </animation>
@@ -7105,6 +7118,7 @@
                     <property alias="/params/bushkit/property"/>
                     <value>4</value>
                 </equals>
+                <property alias="/params/cockpit/electrical/gear-amphibious"/>
             </and>
         </condition>
     </animation>

--- a/Systems/als-lights.xml
+++ b/Systems/als-lights.xml
@@ -185,11 +185,11 @@
         <input>
             <and>
                 <less-than>
-                    <property>/systems/electrical/volts</property>
+                    <property>systems/electrical/outputs/instrument-lights</property>
                     <value>31.5</value>
                 </less-than>
                 <greater-than>
-                    <property>/systems/electrical/volts</property>
+                    <property>systems/electrical/outputs/instrument-lights</property>
                     <value>20.0</value>
                 </greater-than>
             </and>

--- a/Systems/als-lights.xml
+++ b/Systems/als-lights.xml
@@ -180,4 +180,22 @@
         </output>
     </logic>
 
+    <logic>
+        <name>Amphibious Panel Lights On/Off</name>
+        <input>
+            <and>
+                <less-than>
+                    <property>/systems/electrical/volts</property>
+                    <value>31.5</value>
+                </less-than>
+                <greater-than>
+                    <property>/systems/electrical/volts</property>
+                    <value>20.0</value>
+                </greater-than>
+            </and>
+        </input>
+        <output>
+            <property>/sim/model/c172p/lighting/amphibious</property>
+        </output>
+    </logic>
 </PropertyList>


### PR DESCRIPTION
Issue #533

Right now it ties to `/systems/electrical/volts`.
If the alternator is on and the engine is running or the battery is switched on, the panel gets power.