### PR TITLE
Fix damaged 26" wheel from not displaying.

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -5348,7 +5348,7 @@
                 <property alias="/params/gear_right_broken/property"/>
                 <equals>
                     <property alias="/params/bushkit/property"/>
-                    <value>2</value>
+                    <value>1</value>
                 </equals>
             </and>
         </condition>


### PR DESCRIPTION
Fixes #579 

~~~xml
<animation>
    <type>select</type>
    <object-name>RightWheelBKs</object-name>
    <condition>
        <and>
            <not>
                <property alias="/params/gear_right_broken/property"/>
            </not>
            <equals>
                <property alias="/params/bushkit/property"/>
                <value>1</value>
            </equals>
        </and>
    </condition>
</animation>
~~~
Somehow it got set to 2.