### PR TITLE
Bug 593: Reset pontoon leakage to 0 when undamaged

### DIFF
--- a/Systems/bushkit.xml
+++ b/Systems/bushkit.xml
@@ -282,9 +282,19 @@ Extra weight and drag due to bush wheels, floats and 180 hp engine
             </function>
         </fcs_function>
 
-        <!-- FIXME: How to reset this to 0 on repair? -->
+        <!-- No water leakage as long as pontoon is not damaged or broken -->
+        <switch name="left-pontoon/leaked-water-windup-trigger">
+            <default value="-1"/>
+
+            <test logic="AND" value="0">
+                pontoon-damage/left-pontoon GT 0
+            </test>
+        </switch>
+
+        <!-- If trigger is negative then the integrator is reset to 0 -->
         <pid name="left-pontoon/leaked-water-lbs">
             <input>left-pontoon/leakage-lbs_sec</input>
+            <trigger>left-pontoon/leaked-water-windup-trigger</trigger>
             <kp>0.0</kp>
             <ki>1.0</ki>
             <kd>0.0</kd>
@@ -308,9 +318,19 @@ Extra weight and drag due to bush wheels, floats and 180 hp engine
             </function>
         </fcs_function>
 
-        <!-- FIXME: How to reset this to 0 on repair? -->
+        <!-- No water leakage as long as pontoon is not damaged or broken -->
+        <switch name="right-pontoon/leaked-water-windup-trigger">
+            <default value="-1"/>
+
+            <test logic="AND" value="0">
+                pontoon-damage/right-pontoon GT 0
+            </test>
+        </switch>
+
+        <!-- If trigger is negative then the integrator is reset to 0 -->
         <pid name="right-pontoon/leaked-water-lbs">
             <input>right-pontoon/leakage-lbs_sec</input>
+            <trigger>right-pontoon/leaked-water-windup-trigger</trigger>
             <kp>0.0</kp>
             <ki>1.0</ki>
             <kd>0.0</kd>


### PR DESCRIPTION
Fixes #593 

1. Start near the sea and switch to amphibian or sea plane

2. Get in the air and smash the aircraft to the ground near the water

3. Check that one or both of the pontoons are damaged or broken

4. Press Ctrl+u to get in the air and land on the water

5. You should see the damaged/broken pontoon start sinking a bit

6. Now click the "Repair" button. The leakage should disappear and the pontoon should fully float again.

@andgi To answer your question (in `Systems/bushkit.xml`): to reset a pid's integrator, you set its trigger to a negative value. In this case I used -1 as long as a pontoon is undamaged.