### PR TITLE
Bug 608: Kill engine if propeller is broken

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -253,7 +253,9 @@
         <water-rudder-norm>sim/multiplay/generic/float[5]</water-rudder-norm>
         <engine>
             <rpm>engines/engine[2]/rpm</rpm>
+            <crashed>sim/multiplay/generic/int[3]</crashed>
         </engine>
+
         <!-- TODO To be made MP properties in the future when we get passengers or dual-control -->
         <controls>
             <throttle>/controls/engines/current-engine/throttle</throttle>
@@ -4240,19 +4242,9 @@
         <object-name>Spinner</object-name>
         <object-name>Propeller.Fast</object-name>
         <condition>
-            <and>
-                <not>
-                    <property alias="/params/gear_nose_broken/property"/>
-                </not>
-                <equals>
-                    <property alias="/params/pontoon_left_damaged/property"/>
-                    <value>0</value>
-                </equals>
-                <equals>
-                    <property alias="/params/pontoon_right_damaged/property"/>
-                    <value>0</value>
-                </equals>
-            </and>
+            <not>
+                <property alias="/params/engine/crashed"/>
+            </not>
         </condition>
     </animation>
 
@@ -4262,17 +4254,7 @@
         <object-name>PropellerD</object-name>
         <object-name>SpinnerD</object-name>
         <condition>
-            <or>
-                <property alias="/params/gear_nose_broken/property"/>
-                <not-equals>
-                    <property alias="/params/pontoon_left_damaged/property"/>
-                    <value>0</value>
-                </not-equals>
-                <not-equals>
-                    <property alias="/params/pontoon_right_damaged/property"/>
-                    <value>0</value>
-                </not-equals>
-            </or>
+            <property alias="/params/engine/crashed"/>
         </condition>
     </animation>
 

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -299,7 +299,7 @@ var reset_system = func {
     props.globals.getNode("/fdm/jsbsim/pontoon-damage/left-pontoon", 0).setIntValue(0);
     props.globals.getNode("/fdm/jsbsim/pontoon-damage/right-pontoon", 0).setIntValue(0);
 
-    setprop("/engines/active-engine/killed", 0);
+    setprop("/engines/active-engine/kill-engine", 0);
     setprop("/fdm/jsbsim/contact/unit[4]/z-position", 50);
     setprop("/fdm/jsbsim/contact/unit[5]/z-position", 50);
 
@@ -322,13 +322,11 @@ var reset_system = func {
 # Engine coughing sound
 ############################################
 
-var coughing_engine_sound = func{
-    if (getprop("/engines/active-engine/running") and getprop("/engines/active-engine/killed")) {
+setlistener("/engines/active-engine/killed", func (node) {
+    if (node.getValue() and getprop("/engines/active-engine/running")) {
         click("coughing-engine-sound", 0.7, 0);
     };
-}
-
-setlistener("/engines/active-engine/killed", coughing_engine_sound);
+});
 
 ############################################
 # Global loop function

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -124,9 +124,15 @@ var engine_coughing = maketimer(3.0, func {
     var coughing = getprop("/engines/active-engine/coughing");
     var running = getprop("/engines/active-engine/running");
     if (coughing and running) {
-        var delay = 3.0 * rand();
-        # engine.xml will force an engine back to killed == 0 if oil level is still all right
-        settimer(func {setprop("/engines/active-engine/killed", 1);}, delay);
+        var delay = 10.0 * rand();
+        settimer(func {
+            setprop("/engines/active-engine/kill-engine", 1);
+
+            # Bring the engine back to life after 0.25 seconds
+            settimer(func {
+                setprop("/engines/active-engine/kill-engine", 0);
+            }, 0.25);
+        }, delay);
     };
 });
 

--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -3,7 +3,8 @@ var contact = "fdm/jsbsim/contact/";
 
 var reset_all_damage = func
 {
-    setprop("/engines/active-engine/killed", 0);
+    setprop("/engines/active-engine/crash-engine", 0);
+    setprop("/engines/active-engine/kill-engine", 0);
 
     setprop(gears~"unit[0]/broken", 0);
     setprop(gears~"unit[1]/broken", 0);
@@ -50,7 +51,6 @@ var nosegearbroke = func (bushkit)
         setprop(contact~"unit[6]/z-position", -17.7);
 
     setprop(gears~"unit[0]/z-position", 0);
-    killengine();
 }
 
 var leftgearbroke = func (bushkit)
@@ -106,7 +106,7 @@ var upsidedown = func
 
 var killengine = func
 {
-    setprop("/engines/active-engine/killed", 1);
+    setprop("/engines/active-engine/crash-engine", 1);
 }
 
 var defaulttires = func
@@ -325,9 +325,6 @@ setlistener("/sim/signals/fdm-initialized", func {
             else
                 gui.popupTip("Left pontoon DAMAGED!", 5);
         }
-
-        if (left_pontoon != 0)
-            killengine();
     }, 0, 0);
 
     setlistener("/fdm/jsbsim/pontoon-damage/right-pontoon", func (n) {
@@ -346,8 +343,5 @@ setlistener("/sim/signals/fdm-initialized", func {
             else
                 gui.popupTip("Right pontoon DAMAGED!", 5);
         }
-
-        if (right_pontoon != 0)
-            killengine();
     }, 0, 0);
 });

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -135,6 +135,29 @@
         </output>
     </logic>
 
+    <logic>
+        <name>Engine Crashed</name>
+        <input>
+            <or>
+                <property>/engines/active-engine/crash-engine</property>
+
+                <!-- Nose gear broken or pontoons damaged or broken crashes engine -->
+                <property>/fdm/jsbsim/gear/unit[0]/broken</property>
+                <not-equals>
+                    <property>/fdm/jsbsim/pontoon-damage/left-pontoon</property>
+                    <value>0</value>
+                </not-equals>
+                <not-equals>
+                    <property>/fdm/jsbsim/pontoon-damage/right-pontoon</property>
+                    <value>0</value>
+                </not-equals>
+            </or>
+        </input>
+        <output>
+            <property>/engines/active-engine/crashed</property>
+        </output>
+    </logic>
+
     <filter>
         <name>Engine MP-OSI</name>
         <type>gain</type>
@@ -457,11 +480,14 @@
     <!-- Fuel contamination and low oil level                           -->
     <!-- ============================================================== -->
     
-    <!-- High level of fuel contamination or low level of oil kills engine -->
-      <logic>
-        <name>Killing engine</name>
+    <logic>
+        <name>Engine Killed</name>
         <input>
             <or>
+                <property>/engines/active-engine/crashed</property>
+                <property>/engines/active-engine/kill-engine</property>
+
+                <!-- High level of fuel contamination or low level of oil kills engine -->
                 <and>
                     <property>consumables/fuel/tank[0]/selected</property>
                     <greater-than>
@@ -489,7 +515,7 @@
     
     <!-- Low level of fuel contamination or just above oil minimal level makes engine cough-->
     <logic>
-        <name>Engine coughing</name>
+        <name>Engine Coughing</name>
         <input>
             <or>
                 <and>

--- a/Systems/flight-recorder/components/engine.xml
+++ b/Systems/flight-recorder/components/engine.xml
@@ -31,6 +31,16 @@
         <property type="string">/engines/active-engine/killed</property>
     </signal>
 
+    <signal>
+        <type>bool</type>
+        <property type="string">/engines/active-engine/crashed</property>
+    </signal>
+
+    <signal>
+        <type>bool</type>
+        <property type="string">/engines/active-engine/coughing</property>
+    </signal>
+
     <!-- ============================================================== -->
     <!-- Controls                                                       -->
     <!-- ============================================================== -->

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -351,7 +351,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
                 <!-- 0 unused -->
                 <!-- 1 unused -->
                 <!-- 2 unused -->
-                <!-- 3 unused -->
+                <int n="3" alias="/engines/active-engine/crashed"/>
                 <int n="4" alias="/sim/model/c172p/lighting/taxi"/>
                 <int n="5" alias="/sim/model/c172p/lighting/landing"/>
                 <int n="6" alias="/fdm/jsbsim/gear/unit[0]/broken"/>
@@ -572,7 +572,8 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         </engine>
 
         <active-engine>
-            <killed type="bool">false</killed>
+            <crash-engine type="bool">false</crash-engine>
+            <kill-engine type="bool">false</kill-engine>
             <oil-level type="double">7.0</oil-level>
             <oil_consumption_allowed type="bool">false</oil_consumption_allowed>
         </active-engine>


### PR DESCRIPTION
Fixes #608 

Not all calls to `killengine()` can be removed (read: moved to XML) because some depend on the altitude at the moment a wing gets damaged.

In `Nasal/engine.nas` I kill the engine temporarily for 0.25 seconds when oil level is low. I have also increased the maximum random duration from 3 to 10 seconds. 3 would give too much coughing.