### PR TITLE
Higher RPM drop when using carb heat

### DIFF
--- a/Systems/c172p-engine.xml
+++ b/Systems/c172p-engine.xml
@@ -44,7 +44,7 @@
             <function>
                 <ifthen>
                     <property>/controls/anti-ice/engine[0]/carb-heat</property>
-                    <value>0.35</value>
+                    <value>0.475</value>
                     <value>0.15185</value>
                 </ifthen>
             </function>
@@ -55,7 +55,7 @@
             <function>
                 <ifthen>
                     <property>/controls/anti-ice/engine[1]/carb-heat</property>
-                    <value>0.35</value>
+                    <value>0.475</value>
                     <value>0.15185</value>
                 </ifthen>
             </function>


### PR DESCRIPTION
Higher RPM drop when using carb heat. Now at full power the drop is around 100 RPM.

Fixes https://github.com/Juanvvc/c172p-detailed/issues/609