### PR TITLE
Bug 608: Prevent Nasal from undoing repairing crashed engine

### DIFF
--- a/Systems/flight-recorder/components/engine.xml
+++ b/Systems/flight-recorder/components/engine.xml
@@ -28,6 +28,14 @@
 
     <signal>
         <type>bool</type>
+        <property type="string">/engines/active-engine/crash-engine</property>
+    </signal>
+    <signal>
+        <type>bool</type>
+        <property type="string">/engines/active-engine/kill-engine</property>
+    </signal>
+    <signal>
+        <type>bool</type>
         <property type="string">/engines/active-engine/killed</property>
     </signal>
 


### PR DESCRIPTION
Exiting the replay mode while aircraft was damaged during replay would not restore the crash state of the engine.

How to reproduce:

1. Crash into the ground to crash (kill) the engine
2. Repair the aircraft (propeller should be OK again)
3. Go to replay mode and let the aircraft crash itself
4. While the propeller is damaged, exit the replay mode

Without the fix the propeller would stay damaged, but with the fix it should be OK again (because you repaired the aircraft before entering replay mode).