### PR TITLE
Bug 613: Mouse wheel direction of overhead air vents is inverted

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -1990,7 +1990,7 @@
             <binding>
                 <command>property-adjust</command>
                 <property>/environment/aircraft-effects/cabin-heat-set</property>
-                <factor>-0.1</factor>
+                <factor>-0.05</factor>
                 <min>0</min>
                 <max>1</max>
                 <wrap>0</wrap>
@@ -2027,7 +2027,7 @@
             <binding>
                 <command>property-adjust</command>
                 <property>/environment/aircraft-effects/cabin-air-set</property>
-                <factor>-0.1</factor>
+                <factor>-0.05</factor>
                 <min>0</min>
                 <max>1</max>
                 <wrap>0</wrap>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -2061,11 +2061,12 @@
         <object-name>AirVent_left</object-name>
         <visible>true</visible>
         <drag-direction>horizontal</drag-direction>
+        <drag-scale-px>-10.0</drag-scale-px>
         <action>
             <binding>
                 <command>property-adjust</command>
                 <property>/controls/climate-control/overhead-vent-front-left</property>
-                <factor>0.1</factor>
+                <factor>-0.05</factor>
                 <min>0</min>
                 <max>1</max>
                 <wrap>false</wrap>
@@ -2099,12 +2100,12 @@
         <object-name>OAT-object</object-name>
         <visible>true</visible>
         <drag-direction>horizontal</drag-direction>
-        <drag-scale-px>-10.0</drag-scale-px>
+        <drag-scale-px>10.0</drag-scale-px>
         <action>
             <binding>
                 <command>property-adjust</command>
                 <property>/controls/climate-control/overhead-vent-front-right</property>
-                <factor>0.1</factor>
+                <factor>-0.05</factor>
                 <min>0</min>
                 <max>1</max>
                 <wrap>false</wrap>


### PR DESCRIPTION
Fixes #613 

Scrolling up moves the air vents away from you, closing them. Dragging should still be the same: in the direction of where you want to move the air vent to.

I have also reduced the increment/decrement step from 10 % to 5 %. Did the same for the cabin heat and air knobs. The tooltips sometimes show a value that is off-by-one (for example, 44 instead of 45). That's something that should be fixed in flightgear/simgear.