### PR TITLE
Bug 666: Set heading offset when clicking on "Autostart"

### DIFF
--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -54,10 +54,10 @@ var autostart = func (msg=1) {
     var fuel_level_left  = getprop("/consumables/fuel/tank[0]/level-norm");
     var fuel_level_right = getprop("/consumables/fuel/tank[1]/level-norm");
 
-    if (fuel_level_left < 0.5)
-        logger.screen.red("Warning: fuel in left tank less than 50 %!");
-    if (fuel_level_right < 0.5)
-        logger.screen.red("Warning: fuel in right tank less than 50 %!");
+    if (fuel_level_left < 0.25)
+        logger.screen.red("Warning: fuel in left tank less than 25%!");
+    if (fuel_level_right < 0.25)
+        logger.screen.red("Warning: fuel in right tank less than 25%!");
 
     setprop("/controls/engines/engine[0]/primer-lever", 0);
     setprop("/controls/engines/engine/primer", 3);

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -40,6 +40,25 @@ var autostart = func (msg=1) {
     setprop("/sim/model/c172p/securing/tiedownR-visible", 0);
     setprop("/sim/model/c172p/securing/tiedownT-visible", 0);
 
+    setprop("/consumables/fuel/tank[0]/water-contamination", 0.0);
+    setprop("/consumables/fuel/tank[1]/water-contamination", 0.0);
+
+    # Oil level warning for lazy pro's
+    var oil_enabled = getprop("/engines/active-engine/oil_consumption_allowed");
+    var oil_level   = getprop("/engines/active-engine/oil-level");
+
+    if (oil_enabled and oil_level < 6.0)
+        logger.screen.red("Warning: low oil level! Check level via oil cap on top of engine!");
+
+    # Fuel level warnings
+    var fuel_level_left  = getprop("/consumables/fuel/tank[0]/level-norm");
+    var fuel_level_right = getprop("/consumables/fuel/tank[1]/level-norm");
+
+    if (fuel_level_left < 0.5)
+        logger.screen.red("Warning: fuel in left tank less than 50 %!");
+    if (fuel_level_right < 0.5)
+        logger.screen.red("Warning: fuel in right tank less than 50 %!");
+
     setprop("/controls/engines/engine[0]/primer-lever", 0);
     setprop("/controls/engines/engine/primer", 3);
 

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -55,9 +55,9 @@ var autostart = func (msg=1) {
     var fuel_level_right = getprop("/consumables/fuel/tank[1]/level-norm");
 
     if (fuel_level_left < 0.25)
-        logger.screen.red("Warning: fuel in left tank less than 25%!");
+        logger.screen.red("Warning: fuel level of the left tank lower than 25%!");
     if (fuel_level_right < 0.25)
-        logger.screen.red("Warning: fuel in right tank less than 25%!");
+        logger.screen.red("Warning: fuel level of the right tank lower than 25%!");
 
     setprop("/controls/engines/engine[0]/primer-lever", 0);
     setprop("/controls/engines/engine/primer", 3);

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -34,6 +34,11 @@ var autostart = func (msg=1) {
 
     # Pre-flight inspection
     setprop("/sim/model/c172p/brake-parking", 0);
+    setprop("/sim/model/c172p/securing/chock", 0);
+    setprop("/sim/model/c172p/securing/pitot-cover-visible", 0);
+    setprop("/sim/model/c172p/securing/tiedownL-visible", 0);
+    setprop("/sim/model/c172p/securing/tiedownR-visible", 0);
+    setprop("/sim/model/c172p/securing/tiedownT-visible", 0);
 
     setprop("/controls/engines/engine[0]/primer-lever", 0);
     setprop("/controls/engines/engine/primer", 3);

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -89,21 +89,29 @@ var primerTimer = maketimer(5, func {
 # ========== oil consumption ======================
 
 var oil_consumption = maketimer(1.0, func {
-    var oil_level = getprop("/engines/active-engine/oil-level");
+    if (getprop("/engines/active-engine/oil_consumption_allowed"))
+        var oil_level = getprop("/engines/active-engine/oil-level");
+    else
+        var oil_level = 7.0;
     var rpm = getprop("/engines/active-engine/rpm");
-    # quadratic formula which outputs 1.0 for input 2300 RPM (cruise value), 0.6 for 700 RPM (idle) and 1.2 for 2700 RPM (max)
-    var rpm_factor = 0.00000012 * math.pow(rpm,2) - 0.0001 * rpm + 0.62;
-    # consumption rate defined as 1.5 quarter per 10 hours (36000 seconds) at cruise RPM
+
+    # Quadratic formula which outputs 1.0 for input 2300 RPM (cruise value),
+    # 0.6 for 700 RPM (idle) and 1.2 for 2700 RPM (max)
+    var rpm_factor = 0.00000012 * math.pow(rpm, 2) - 0.0001 * rpm + 0.62;
+
+    # Consumption rate defined as 1.5 quarter per 10 hours (36000 seconds)
+    # at cruise RPM
     var consumption_rate = 1.5 / 36000; 
+
     var low_oil_pressure_factor = 1.0;
     var low_oil_temperature_factor = 1.0;
-    
-    if ((getprop("/engines/active-engine/running")) and (getprop("/engines/active-engine/oil_consumption_allowed"))) {
+
+    if (getprop("/engines/active-engine/running")) {
         oil_level = oil_level - consumption_rate * rpm_factor;
         setprop("/engines/active-engine/oil-level", oil_level);        
     }
-    
-    # If oil gets low, pressure should lower and temperature should rise
+
+    # If oil gets low (< 5.0), pressure should drop and temperature should rise
     var oil_level_limited = std.min(oil_level, 5.0);
 
     # Should give 1.0 for oil_level = 5 and 0.1 for oil_level 4.92,

--- a/c172p-keyboard.xml
+++ b/c172p-keyboard.xml
@@ -131,4 +131,13 @@
         </binding>
     </key>
 
+    <key n="265">
+        <name>F9</name>
+        <desc>Popup Fuel and Payload Settings dialog</desc>
+        <binding>
+            <command>nasal</command>
+            <script>gui.showWeightDialog()</script>
+        </binding>
+    </key>
+
 </PropertyList>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -503,27 +503,27 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
     <consumables>
         <fuel>
             <tank n="0">
-                <name>LeftTank</name>
+                <name>Left tank</name>
                 <level-gal_us type="double">20</level-gal_us>
                 <selected type="bool">true</selected>
                 <water-contamination type="double">0.0</water-contamination>
                 <fuel-sample-taken type="bool">false</fuel-sample-taken>
             </tank>
             <tank n="1">
-                <name>RightTank</name>
+                <name>Right tank</name>
                 <level-gal_us type="double">20</level-gal_us>
                 <selected type="bool">true</selected>
                 <water-contamination type="double">0.0</water-contamination>
                 <fuel-sample-taken type="bool">false</fuel-sample-taken>
             </tank>
             <tank n="2">
-                <name>Float chamber1</name>
+                <name>Float chamber 1</name>
                 <capacity unit="LBS"> 0.1 </capacity>
                 <selected type="bool">true</selected>
                 <hidden type="bool">true</hidden>
             </tank>
             <tank n="3">
-                <name>Float chamber2</name>
+                <name>Float chamber 2</name>
                 <capacity unit="LBS"> 0.1 </capacity>
                 <selected type="bool">true</selected>
                 <hidden type="bool">true</hidden>


### PR DESCRIPTION
Fixes #666 

This PR changes the behavior of "Autostart": when clicking on it, the tiedowns, chocks, and pitot tube cover are no longer removed. The reasoning is that they are only visible if the user has chosen to enable "Allow securing aircraft", and having that option enabled indicates that the user wants these things.

This change is debatable and I can revert it if too many people disagree.