### PR TITLE
Turn on TaxiLightCone and LandingLightCone objects.

### DIFF
--- a/Models/c172p.ac
+++ b/Models/c172p.ac
@@ -26,7 +26,7 @@ MATERIAL "mat_antenna" rgb 0.8900 0.8900 0.8900  amb 0.8900 0.8900 0.8900  emis 
 MATERIAL "TrimWheelMat" rgb 0.7632 0.7632 0.7632  amb 0.1146 0.1146 0.1146  emis 0.0000 0.0000 0.0000  spec 0.7274 0.7274 0.7274  shi 50 trans 0.0000
 OBJECT world
 name "Blender_export__c172p.ac"
-kids 86
+kids 88
 OBJECT poly
 name "AirVent_left"
 loc 0.0234935 -0.0140961 -0.0000000
@@ -95684,6 +95684,63 @@ refs 4
 1 0 0
 kids 0
 OBJECT poly
+name "LandingLightCone"
+texture "panel.png"
+texrep 1 1
+numvert 8
+0.5129240 -10.2251234 -9.9864159
+0.5129240 -10.2251234 10.0135775
+-199.4870758 -100.2251205 100.0135345
+-199.4870300 -100.2251205 -99.9864883
+0.5129320 9.7748804 -9.9864159
+0.5129240 9.7748804 10.0135832
+-199.4870911 99.7748795 100.0135117
+-199.4870605 99.7748795 -99.9864502
+numsurf 6
+SURF 0X20
+mat 2
+refs 4
+0 0 0
+1 0 0
+2 0 0
+3 0 0
+SURF 0X20
+mat 2
+refs 4
+4 0 0
+7 0 0
+6 0 0
+5 0 0
+SURF 0X20
+mat 2
+refs 4
+0 0 0
+4 0 0
+5 0 0
+1 0 0
+SURF 0X20
+mat 2
+refs 4
+1 0 0
+5 0 0
+6 0 0
+2 0 0
+SURF 0X20
+mat 2
+refs 4
+2 0 0
+6 0 0
+7 0 0
+3 0 0
+SURF 0X20
+mat 2
+refs 4
+4 0 0
+0 0 0
+3 0 0
+7 0 0
+kids 0
+OBJECT poly
 name "landinglightcover"
 numvert 11
 -0.0110850 0.4716430 2.6822100
@@ -125929,6 +125986,63 @@ refs 4
 3 0.821499 0.248225
 11 0.821499 0.248225
 9 0.821499 0.248225
+kids 0
+OBJECT poly
+name "TaxiLightCone"
+texture "panel.png"
+texrep 1 1
+numvert 8
+0.5129240 -10.2251234 -9.9864159
+0.5129240 -10.2251234 10.0135775
+-75.4046707 -66.6569443 100.0135269
+-75.4046173 -66.6569443 -99.9864883
+0.5129320 9.7748804 -9.9864159
+0.5129240 9.7748804 10.0135832
+-109.5723114 45.8260078 100.0135117
+-109.5722656 45.8260078 -99.9864502
+numsurf 6
+SURF 0X20
+mat 2
+refs 4
+0 0 0
+1 0 0
+2 0 0
+3 0 0
+SURF 0X20
+mat 2
+refs 4
+4 0 0
+7 0 0
+6 0 0
+5 0 0
+SURF 0X20
+mat 2
+refs 4
+0 0 0
+4 0 0
+5 0 0
+1 0 0
+SURF 0X20
+mat 2
+refs 4
+1 0 0
+5 0 0
+6 0 0
+2 0 0
+SURF 0X20
+mat 2
+refs 4
+2 0 0
+6 0 0
+7 0 0
+3 0 0
+SURF 0X20
+mat 2
+refs 4
+4 0 0
+0 0 0
+3 0 0
+7 0 0
 kids 0
 OBJECT poly
 name "TiedownHotSpotLeft"


### PR DESCRIPTION
I see these never got corrected so here is the fix for it. Also there is a couple objects that are not being used for anything leftwindow_int and rightwindow_int.

I also just added a commit correcting a material error that crept in from somewhere.