### PR TITLE
animate adf compass card

### DIFF
--- a/WebPanel/ADF.json
+++ b/WebPanel/ADF.json
@@ -3,6 +3,19 @@
 
     "animations": [
       {
+        "element": "#Card",
+        "type":    "transform",
+        "transforms": [{
+          "type": "rotate",
+          "a": {
+            "property": "adf-rotation-deg",
+            "scale": -1,
+            "precision": 5
+          },
+          "x": 256,
+          "y": 256
+        }]
+      },{
         "element": "#Needle",
         "type":    "transform",
         "transforms": [{

--- a/WebPanel/c172p-webpanel-properties.json
+++ b/WebPanel/c172p-webpanel-properties.json
@@ -19,6 +19,7 @@
     ["egt",         "/engines/active-engine/egt-norm"],
     ["egtBug",      "/engines/engine[0]/egt-bug-norm"],
     ["adf",         "/instrumentation/adf[0]/indicated-bearing-deg"],
+    ["adf-rotation-deg",         "/instrumentation/adf/rotation-deg"],
 
     ["aileron",     "/controls/flight/aileron"],
     ["elevator",    "/controls/flight/elevator"],


### PR DESCRIPTION
This animates the compass-card of the ADF gauge. It is not automatically rotated, nor does it affect the needle in any way (like the VOR radial dial does) but it still has a knob that can be rotated to your current course, for example.