### PR TITLE
Calibrated airspeed --> indicated airspeed conversion

### DIFF
--- a/Models/Interior/Panel/Instruments/asi/asi.xml
+++ b/Models/Interior/Panel/Instruments/asi/asi.xml
@@ -26,7 +26,7 @@
  <animation>
   <type>rotate</type>
   <object-name>Needle</object-name>
-  <property>instrumentation/airspeed-indicator/indicated-speed-kt</property>
+  <property>fdm/jsbsim/velocities/vias-kts</property>
   <interpolation>
    <entry><ind>   0</ind><dep>    0</dep></entry>
    <entry><ind>  35</ind><dep>   36</dep></entry>

--- a/Systems/indicated-airspeed.xml
+++ b/Systems/indicated-airspeed.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+    <system name="indicated-airspeed">
+        
+        <!-- Largely inspired from c182, thanks HHS81 -->
+        
+        <!-- IAS Indicated airspeed (IAS) is the airspeed indicator reading (ASIR) uncorrected for instrument, position, and other errors. 
+        From current EASA definitions: Indicated airspeed means the speed of an aircraft as shown on its pitot static airspeed indicator calibrated to reflect 
+        standard atmosphere adiabatic compressible flow at sea level uncorrected for airspeed system errors
+        Calibrated airspeed (CAS) is indicated airspeed corrected for instrument errors, position error (due to incorrect pressure at the static port) and installation errors.
+        According the POH Skyhawk C172P-1982 on Page 5-9 airspeed calibration shows a large difference between KIAS and KCAS at lower speeds than 90 and above. 
+        It seems this is not reflected by JSBSim or FlightGear in a realistic way.
+        So use this numbers and create a table which corrects the output shown on the ASI
+        -->
+
+        <channel name="indicated airspeed">
+    
+            <fcs_function name="systems/asi/indicated-airspeed">
+                <function>
+                    <table>
+                        <independentVar lookup="row">velocities/vc-kts</independentVar>
+                        <independentVar lookup="column">fcs/flap-pos-deg</independentVar>
+                        <tableData>
+                                  0     10    30
+                            0     0     0     0
+                            47    38    38    40
+                            49    40    40    42
+                            53    45    47    50
+                            55    49    50    52
+                            56    50    51    54
+                            62    60    60    61
+                            70    70    70    70
+                            80    81    81    80
+                            89    90    90    90
+                            98    100   100   100
+                            107   110   109   109
+                            117   120   120   120
+                            126   130   130   130
+                            135   140   140   140
+                            145   150   150   150
+                            154   160   160   160
+                        </tableData> 
+                    </table>  
+                </function>
+                <output>velocities/vias-kts</output>   
+            </fcs_function>
+        </channel>
+    </system>

--- a/Systems/indicated-airspeed.xml
+++ b/Systems/indicated-airspeed.xml
@@ -1,48 +1,77 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-    <system name="indicated-airspeed">
-        
-        <!-- Largely inspired from c182, thanks HHS81 -->
-        
-        <!-- IAS Indicated airspeed (IAS) is the airspeed indicator reading (ASIR) uncorrected for instrument, position, and other errors. 
-        From current EASA definitions: Indicated airspeed means the speed of an aircraft as shown on its pitot static airspeed indicator calibrated to reflect 
-        standard atmosphere adiabatic compressible flow at sea level uncorrected for airspeed system errors
-        Calibrated airspeed (CAS) is indicated airspeed corrected for instrument errors, position error (due to incorrect pressure at the static port) and installation errors.
-        According the POH Skyhawk C172P-1982 on Page 5-9 airspeed calibration shows a large difference between KIAS and KCAS at lower speeds than 90 and above. 
-        It seems this is not reflected by JSBSim or FlightGear in a realistic way.
-        So use this numbers and create a table which corrects the output shown on the ASI
-        -->
+<!--
+    Copyright (c) 2016 HHS81 and dany93
 
-        <channel name="indicated airspeed">
-    
-            <fcs_function name="systems/asi/indicated-airspeed">
-                <function>
-                    <table>
-                        <independentVar lookup="row">velocities/vc-kts</independentVar>
-                        <independentVar lookup="column">fcs/flap-pos-deg</independentVar>
-                        <tableData>
-                                  0     10    30
-                            0     0     0     0
-                            47    38    38    40
-                            49    40    40    42
-                            53    45    47    50
-                            55    49    50    52
-                            56    50    51    54
-                            62    60    60    61
-                            70    70    70    70
-                            80    81    81    80
-                            89    90    90    90
-                            98    100   100   100
-                            107   110   109   109
-                            117   120   120   120
-                            126   130   130   130
-                            135   140   140   140
-                            145   150   150   150
-                            154   160   160   160
-                        </tableData> 
-                    </table>  
-                </function>
-                <output>velocities/vias-kts</output>   
-            </fcs_function>
-        </channel>
-    </system>
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<system name="indicated-airspeed">
+        
+<!--
+    (dany93) Largely inspired from c182, thanks HHS81.
+-->
+        
+<!--
+    IAS Indicated airspeed (IAS) is the airspeed indicator reading(ASIR)
+    uncorrected for instrument, position, and other errors. 
+    From current EASA definitions: Indicated airspeed means the speed of
+    an aircraft as shown on its pitot static airspeed indicator 
+    calibrated to reflect standard atmosphere adiabatic compressible 
+    flow at sea level uncorrected for airspeed system errors.
+    Calibrated airspeed (CAS) is indicated airspeed corrected for
+    instrument errors, position error (due to incorrect pressure at the 
+    static port) and installation errors.
+    According the POH Skyhawk C172P-1982 on Page 5-9 airspeed
+    calibration shows a large difference between KIAS and KCAS at lower 
+    speeds than 90 and above. 
+    It seems this is not reflected by JSBSim or FlightGear in a 
+    realistic way.
+    So use this numbers and create a table which corrects the
+    output shown on the ASI.
+-->
+
+    <channel name="indicated airspeed">
+
+        <fcs_function name="systems/asi/indicated-airspeed">
+            <function>
+                <table>
+                    <independentVar lookup="row">velocities/vc-kts</independentVar>
+                    <independentVar lookup="column">fcs/flap-pos-deg</independentVar>
+                    <tableData>
+                              0     10    30
+                        0     0     0     0
+                        47    38    38    40
+                        49    40    40    42
+                        53    45    47    50
+                        55    49    50    52
+                        56    50    51    54
+                        62    60    60    61
+                        70    70    70    70
+                        80    81    81    80
+                        89    90    90    90
+                        98    100   100   100
+                        107   110   109   109
+                        117   120   120   120
+                        126   130   130   130
+                        135   140   140   140
+                        145   150   150   150
+                        154   160   160   160
+                    </tableData> 
+                </table>  
+            </function>
+            <output>velocities/vias-kts</output>   
+        </fcs_function>
+    </channel>
+</system>

--- a/c172p.xml
+++ b/c172p.xml
@@ -1001,7 +1001,6 @@
                 </traverse>
             </kinematic>
         </channel>
-
     </flight_control>
 
     <aerodynamics>
@@ -1869,6 +1868,7 @@
     <system file="c172p-damage"/>
     <system file="c172p-sounds"/>
     <system file="c172p-heat"/>
+    <system file="indicated-airspeed"/>
 
     <!--
     <output name="JSBout172C.csv" type="CSV" rate="60">


### PR DESCRIPTION
Conversion from Calibrated airspeed (previously: indicated on the instrument) to Indicated airspeed  taking into account the aerodynamics and instrumental errors. According to the C172P 1982 POH, page 5.9 (PDF 85/357).
About issue https://github.com/Juanvvc/c172p-detailed/issues/676.