### PR TITLE
Bug 723: Use indicated-speed-kt which uses an almost perfect pitot, but can fail

### DIFF
--- a/Systems/indicated-airspeed.xml
+++ b/Systems/indicated-airspeed.xml
@@ -42,12 +42,20 @@
     output shown on the ASI.
 -->
 
+    <property>/instrumentation/airspeed-indicator/indicated-speed-kt</property>
+
     <channel name="indicated airspeed">
 
         <fcs_function name="systems/asi/indicated-airspeed">
+            <output>velocities/vias-kts</output>
             <function>
                 <table>
-                    <independentVar lookup="row">velocities/vc-kts</independentVar>
+                    <!-- The indicated-speed-kt property reacts to pitot
+                         failure, but it assumes the pitot is perfect.
+                         Therefore, it practically reacts as a calibrated
+                         airspeed indicator (KCAS).
+                    -->
+                    <independentVar lookup="row">/instrumentation/airspeed-indicator/indicated-speed-kt</independentVar>
                     <independentVar lookup="column">fcs/flap-pos-deg</independentVar>
                     <tableData>
                               0     10    30
@@ -73,11 +81,11 @@
             </function>
         </fcs_function>
 
-        <switch name="systems/asi/indicated-airspeed-serviceable">
-            <output>velocities/vias-kts</output>
-            <default value="systems/asi/indicated-airspeed"/>
+        <switch name="systems/asi/pitot-serviceable">
+            <output>/systems/pitot/serviceable</output>
+            <default value="1"/>
 
-            <test logic="AND" value="0.0">
+            <test logic="AND" value="0">
                 /sim/model/c172p/securing/pitot-cover-visible EQ 1
             </test>
         </switch>


### PR DESCRIPTION
Fixes #723 

`/fdm/jsbsim/velocities/vc-kts` does not react to failure of the pitot
system. Use `/instrumentation/airspeed-indicator/indicated-speed-kt` which
does depend on the pitot system. Note that the indicated airspeed system
assumes a perfect pitot, thus it practically is a calibrated airspeed
indicator.

There's a small difference between `vc-kts` and `indicated-speed-kt` (see https://github.com/Juanvvc/c172p-detailed/issues/723#issuecomment-191188420) but it is quite small (< 1 kt usually).