### PR TITLE
FDM: add (straight backwards) propwash effect for 180 hp version

### DIFF
--- a/c172p.xml
+++ b/c172p.xml
@@ -1067,6 +1067,7 @@
             <sum>
                 <property>velocities/u-aero-fps</property>
                 <property>propulsion/engine/prop-induced-velocity_fps</property>
+                <property>propulsion/engine[1]/prop-induced-velocity_fps</property>
             </sum>
         </function>
 


### PR DESCRIPTION
Straight backwards propwash effect was already implemented for the 160 hp version, but it had been forgotten when adding the 180 hp engine.

**To check it in the simulator (stopped on the ground with no or negligible wind):**
- 180hp
- parking brake ON
- Full or enough RPM
- Pull the yoke (elevator up) ==> the nose pitches up (the tail goes down due to propwash)

Not so easy for the effect on the rudder.

Checking it in the Internal properties:
- `fdm/jsbsim/aero/coefficient/Cmde` (Pitch_moment_due_to_elevator_deflection)
- `fdm/jsbsim/aero/coefficient/Cndr` (Yaw_moment_due_to_rudder)

_(among other effects, can be used to relieve the strain on the nose wheel when rolling on a bad ground)_
