### PR TITLE
updating marker.xml path

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -713,7 +713,7 @@
     </model>
 
     <model>
-        <path>Models/Aircraft/marker.xml</path>
+        <path>Aircraft/Generic/marker.xml</path>
     </model>
 
     <!-- Breakers and avionics switch -->


### PR DESCRIPTION
Torsten moved the file marker.xml in FGDATA from `Models/Aircraft` to `Aircraft/Generic`, and so we must update our reference to it.

Fixes https://github.com/Juanvvc/c172p-detailed/issues/733