### PR TITLE
better conditional for oil dialog

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -7922,6 +7922,9 @@
                 <condition>
                     <and>
                         <property>/engines/active-engine/oil_consumption_allowed</property>
+                        <not>
+                            <property>/engines/active-engine/running</property>
+                        </not>
                         <equals>
                             <property>/controls/engines/active-engine</property>
                             <value>0</value>
@@ -7935,6 +7938,9 @@
                 <condition>
                     <and>
                         <property>/engines/active-engine/oil_consumption_allowed</property>
+                        <not>
+                            <property>/engines/active-engine/running</property>
+                        </not>
                         <equals>
                             <property>/controls/engines/active-engine</property>
                             <value>1</value>
@@ -7944,11 +7950,28 @@
                 <command>dialog-show</command>
                 <dialog-name>c172p-oil-dialog-180</dialog-name>
             </binding>
+            <binding>
+                <condition>
+                    <and>
+                        <property>/engines/active-engine/running</property>
+                        <property>/engines/active-engine/oil_consumption_allowed</property>
+                    </and>
+                </condition>
+                <command>nasal</command>
+                <script>
+                    gui.popupTip("You can't check the oil level with the engine running!");
+                </script>
+            </binding>
         </action>
         <hovered>
             <binding>
                 <condition>
-                    <property>/engines/active-engine/oil_consumption_allowed</property>
+                    <and>
+                        <not>
+                            <property>/engines/active-engine/running</property>
+                        </not>
+                        <property>/engines/active-engine/oil_consumption_allowed</property>
+                    </and>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>oil-sump</tooltip-id>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -7996,7 +7996,7 @@
                 </condition>
                 <command>nasal</command>
                 <script>
-                    gui.popupTip("You can't check the oil level while on the air!");
+                    gui.popupTip("You can't check the oil level while in the air!");
                 </script>
             </binding>
         </action>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -7925,6 +7925,12 @@
                         <not>
                             <property>/engines/active-engine/running</property>
                         </not>
+                        <or>
+                            <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
+                            <property>/fdm/jsbsim/hydro/active-norm</property>
+                        </or>
                         <equals>
                             <property>/controls/engines/active-engine</property>
                             <value>0</value>
@@ -7941,6 +7947,12 @@
                         <not>
                             <property>/engines/active-engine/running</property>
                         </not>
+                        <or>
+                            <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
+                            <property>/fdm/jsbsim/hydro/active-norm</property>
+                        </or>
                         <equals>
                             <property>/controls/engines/active-engine</property>
                             <value>1</value>
@@ -7954,12 +7966,37 @@
                 <condition>
                     <and>
                         <property>/engines/active-engine/running</property>
+                        <or>
+                            <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
+                            <property>/fdm/jsbsim/hydro/active-norm</property>
+                        </or>
                         <property>/engines/active-engine/oil_consumption_allowed</property>
                     </and>
                 </condition>
                 <command>nasal</command>
                 <script>
                     gui.popupTip("You can't check the oil level with the engine running!");
+                </script>
+            </binding>
+            <binding>
+                <condition>
+                    <and>
+                        <not>
+                            <or>
+                                <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
+                                <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                                <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
+                                <property>/fdm/jsbsim/hydro/active-norm</property>
+                            </or>
+                        </not>
+                        <property>/engines/active-engine/oil_consumption_allowed</property>
+                    </and>
+                </condition>
+                <command>nasal</command>
+                <script>
+                    gui.popupTip("You can't check the oil level while on the air!");
                 </script>
             </binding>
         </action>
@@ -7970,6 +8007,12 @@
                         <not>
                             <property>/engines/active-engine/running</property>
                         </not>
+                        <or>
+                            <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
+                            <property>/fdm/jsbsim/hydro/active-norm</property>
+                        </or>
                         <property>/engines/active-engine/oil_consumption_allowed</property>
                     </and>
                 </condition>

--- a/gui/dialogs/c172p-oil-160.xml
+++ b/gui/dialogs/c172p-oil-160.xml
@@ -10,13 +10,15 @@
 
     <group>
         <layout>hbox</layout>
-
-        <empty><stretch>true</stretch></empty>
+        <empty>
+            <stretch>true</stretch>
+        </empty>
         <text>
             <label>Oil Level</label>
         </text>
-        <empty><stretch>true</stretch></empty>
-
+        <empty>
+            <stretch>true</stretch>
+        </empty>
         <button>
             <legend/>
             <key>Esc</key>
@@ -46,10 +48,17 @@
                 <max>7.0</max>
                 <live>true</live>
                 <enable>
-                    <less-than>
-                        <property>velocities/groundspeed-kt</property>
-                        <value>1.0</value>
-                    </less-than>
+                    <and>
+                        <or>
+                            <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
+                            <property>/fdm/jsbsim/hydro/active-norm</property>
+                        </or>
+                        <not>
+                            <property>/engines/active-engine/running</property>
+                        </not>
+                    </and>
                 </enable>
                 <property>/engines/active-engine/oil-level</property>
                 <binding>
@@ -79,17 +88,14 @@
         <layout>hbox</layout>
         <text>
             <visible>
-                <greater-than-equals>
-                    <property>velocities/groundspeed-kt</property>
-                    <value>1.0</value>
-                </greater-than-equals>
+                <property>/engines/active-engine/running</property>
             </visible>
             <color>
                 <red>0.9</red>
                 <green>0.1</green>
                 <blue>0.1</blue>
             </color>
-            <label>Dialog disabled when in movement</label>
+            <label>Slider disabled while engine is on</label>
         </text>
     </group>
     

--- a/gui/dialogs/c172p-oil-160.xml
+++ b/gui/dialogs/c172p-oil-160.xml
@@ -125,7 +125,7 @@
                 <green>0.1</green>
                 <blue>0.1</blue>
             </color>
-            <label>Slider disabled while on the air!</label>
+            <label>Slider disabled while in the air!</label>
         </text>
     </group>
     

--- a/gui/dialogs/c172p-oil-160.xml
+++ b/gui/dialogs/c172p-oil-160.xml
@@ -40,7 +40,7 @@
             <layout>hbox</layout>
             <text>
                 <label>Oil Level:</label>
-                <halign>left</halign>
+                <halign>right</halign>
             </text>
             <slider>                
                 <name>c172p-oil-slider-160</name>
@@ -85,17 +85,47 @@
     </group>
     
     <group>
-        <layout>hbox</layout>
+        <layout>table</layout>
         <text>
+            <row>0</row>
+            <col>0</col>
             <visible>
-                <property>/engines/active-engine/running</property>
+                <and>
+                    <or>
+                        <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
+                        <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                        <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
+                        <property>/fdm/jsbsim/hydro/active-norm</property>
+                    </or>
+                    <property>/engines/active-engine/running</property>
+                </and>
             </visible>
             <color>
                 <red>0.9</red>
                 <green>0.1</green>
                 <blue>0.1</blue>
             </color>
-            <label>Slider disabled while engine is running</label>
+            <label>Slider disabled while engine is running!</label>
+        </text>
+        <text>
+            <row>0</row>
+            <col>0</col>
+            <visible>
+                <not>
+                    <or>
+                        <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
+                        <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                        <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
+                        <property>/fdm/jsbsim/hydro/active-norm</property>
+                    </or>
+                </not>
+            </visible>
+            <color>
+                <red>0.9</red>
+                <green>0.1</green>
+                <blue>0.1</blue>
+            </color>
+            <label>Slider disabled while on the air!</label>
         </text>
     </group>
     

--- a/gui/dialogs/c172p-oil-160.xml
+++ b/gui/dialogs/c172p-oil-160.xml
@@ -95,7 +95,7 @@
                 <green>0.1</green>
                 <blue>0.1</blue>
             </color>
-            <label>Slider disabled while engine is on</label>
+            <label>Slider disabled while engine is running</label>
         </text>
     </group>
     

--- a/gui/dialogs/c172p-oil-180.xml
+++ b/gui/dialogs/c172p-oil-180.xml
@@ -41,7 +41,7 @@
             <layout>hbox</layout>
             <text>
                 <label>Oil Level:</label>
-                <halign>left</halign>
+                <halign>right</halign>
             </text>
             <slider>
                 <name>c172p-oil-slider-180</name>
@@ -86,17 +86,47 @@
     </group>
     
     <group>
-        <layout>hbox</layout>
+        <layout>table</layout>
         <text>
+            <row>0</row>
+            <col>0</col>
             <visible>
-                <property>/engines/active-engine/running</property>
+                <and>
+                    <or>
+                        <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
+                        <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                        <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
+                        <property>/fdm/jsbsim/hydro/active-norm</property>
+                    </or>
+                    <property>/engines/active-engine/running</property>
+                </and>
             </visible>
             <color>
                 <red>0.9</red>
                 <green>0.1</green>
                 <blue>0.1</blue>
             </color>
-            <label>Slider disabled while engine is running</label>
+            <label>Slider disabled while engine is running!</label>
+        </text>
+        <text>
+            <row>0</row>
+            <col>0</col>
+            <visible>
+                <not>
+                    <or>
+                        <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
+                        <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                        <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
+                        <property>/fdm/jsbsim/hydro/active-norm</property>
+                    </or>
+                </not>
+            </visible>
+            <color>
+                <red>0.9</red>
+                <green>0.1</green>
+                <blue>0.1</blue>
+            </color>
+            <label>Slider disabled while on the air!</label>
         </text>
     </group>
     

--- a/gui/dialogs/c172p-oil-180.xml
+++ b/gui/dialogs/c172p-oil-180.xml
@@ -10,12 +10,15 @@
 
     <group>
         <layout>hbox</layout>
-
-        <empty><stretch>true</stretch></empty>
+        <empty>
+            <stretch>true</stretch>
+        </empty>
         <text>
             <label>Oil Level</label>
         </text>
-        <empty><stretch>true</stretch></empty>
+        <empty>
+            <stretch>true</stretch>
+        </empty>
 
         <button>
             <legend/>
@@ -46,10 +49,17 @@
                 <max>8.0</max>
                 <live>true</live>
                 <enable>
-                    <less-than>
-                        <property>velocities/groundspeed-kt</property>
-                        <value>1.0</value>
-                    </less-than>
+                    <and>
+                        <or>
+                            <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
+                            <property>/fdm/jsbsim/hydro/active-norm</property>
+                        </or>
+                        <not>
+                            <property>/engines/active-engine/running</property>
+                        </not>
+                    </and>
                 </enable>
                 <property>/engines/active-engine/oil-level</property>
                 <binding>
@@ -79,17 +89,14 @@
         <layout>hbox</layout>
         <text>
             <visible>
-                <greater-than-equals>
-                    <property>velocities/groundspeed-kt</property>
-                    <value>1.0</value>
-                </greater-than-equals>
+                <property>/engines/active-engine/running</property>
             </visible>
             <color>
                 <red>0.9</red>
                 <green>0.1</green>
                 <blue>0.1</blue>
             </color>
-            <label>Dialog disabled when in movement</label>
+            <label>Slider disabled while engine is on</label>
         </text>
     </group>
     

--- a/gui/dialogs/c172p-oil-180.xml
+++ b/gui/dialogs/c172p-oil-180.xml
@@ -126,7 +126,7 @@
                 <green>0.1</green>
                 <blue>0.1</blue>
             </color>
-            <label>Slider disabled while on the air!</label>
+            <label>Slider disabled while in the air!</label>
         </text>
     </group>
     

--- a/gui/dialogs/c172p-oil-180.xml
+++ b/gui/dialogs/c172p-oil-180.xml
@@ -96,7 +96,7 @@
                 <green>0.1</green>
                 <blue>0.1</blue>
             </color>
-            <label>Slider disabled while engine is on</label>
+            <label>Slider disabled while engine is running</label>
         </text>
     </group>
     


### PR DESCRIPTION
Better conditional for oil dialogs. 

Closes https://github.com/Juanvvc/c172p-detailed/issues/743

And although discussed in that issue, I have not implemented the same conditionals for the securing objects. I attempted to do so, but the result was buggy and I couldn't narrow down the problems. Also, it looked quite inelegant to add the message "you can't add/remove tiedowns/chocks/pitot tube cover with the engine on" + the conditional to 12 hotspots in the Models.xml (that is, 6 for the tiedowns, 2 for each type of chocks and 2 for the pitot tube cover). I am not sure it's worth all this trouble since they are working just fine as of now (with groundspeed < 1.0). But in case you guys think it's worth to implement this, then do not merge this PR yet and let's discuss how to do it further.