### PR TITLE
Bug 757: better Autostart function

### DIFF
--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -43,14 +43,15 @@ var autostart = func (msg=1) {
     setprop("/consumables/fuel/tank[0]/water-contamination", 0.0);
     setprop("/consumables/fuel/tank[1]/water-contamination", 0.0);        
 
-    # Oil level
-    var oil_enabled = getprop("/engines/active-engine/oil_consumption_allowed");
-    var oil_level   = getprop("/engines/active-engine/oil-level");
-
-    if (oil_enabled and oil_level < 6.0)
+    # Setting max oil level
+    if (getprop("/controls/engines/active-engine") == 0) {
         setprop("/engines/active-engine/oil-level", 7.0);
+    } 
+    else {
+        setprop("/engines/active-engine/oil-level", 8.0);
+    };
 
-    # Fuel level
+    # Checking for minimal fuel level
     var fuel_level_left  = getprop("/consumables/fuel/tank[0]/level-norm");
     var fuel_level_right = getprop("/consumables/fuel/tank[1]/level-norm");
 

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -41,23 +41,23 @@ var autostart = func (msg=1) {
     setprop("/sim/model/c172p/securing/tiedownT-visible", 0);
 
     setprop("/consumables/fuel/tank[0]/water-contamination", 0.0);
-    setprop("/consumables/fuel/tank[1]/water-contamination", 0.0);
+    setprop("/consumables/fuel/tank[1]/water-contamination", 0.0);        
 
-    # Oil level warning for lazy pro's
+    # Oil level
     var oil_enabled = getprop("/engines/active-engine/oil_consumption_allowed");
     var oil_level   = getprop("/engines/active-engine/oil-level");
 
     if (oil_enabled and oil_level < 6.0)
-        logger.screen.red("Warning: low oil level! Check level via oil cap on top of engine!");
+        setprop("/engines/active-engine/oil-level", 7.0);
 
-    # Fuel level warnings
+    # Fuel level
     var fuel_level_left  = getprop("/consumables/fuel/tank[0]/level-norm");
     var fuel_level_right = getprop("/consumables/fuel/tank[1]/level-norm");
 
     if (fuel_level_left < 0.25)
-        logger.screen.red("Warning: fuel level of the left tank lower than 25%!");
+        setprop("/consumables/fuel/tank[0]/level-norm", 0.25);
     if (fuel_level_right < 0.25)
-        logger.screen.red("Warning: fuel level of the right tank lower than 25%!");
+        setprop("/consumables/fuel/tank[1]/level-norm", 0.25);
 
     setprop("/controls/engines/engine[0]/primer-lever", 0);
     setprop("/controls/engines/engine/primer", 3);

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -49,13 +49,14 @@ var autostart = func (msg=1) {
     var oil_enabled = getprop("/engines/active-engine/oil_consumption_allowed");
     var oil_level   = getprop("/engines/active-engine/oil-level");
     
-    if (oil_enabled and oil_level < 6.0)
+    if (oil_enabled and oil_level < 6.0) {
         if (getprop("/controls/engines/active-engine") == 0) {
             setprop("/engines/active-engine/oil-level", 7.0);
         } 
         else {
             setprop("/engines/active-engine/oil-level", 8.0);
         };
+    };
 
     # Checking for minimal fuel level
     var fuel_level_left  = getprop("/consumables/fuel/tank[0]/level-norm");

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -62,8 +62,15 @@ var autostart = func (msg=1) {
     setprop("/controls/engines/engine[0]/primer-lever", 0);
     setprop("/controls/engines/engine/primer", 3);
 
-    if (msg)
-        gui.popupTip("Hold down \"s\" to start the engine", 5);
+    # All set, starting engine
+    setprop("/controls/switches/starter", 1);
+    var engineRunning = setlistener("/engines/active-engine/running", func {
+        if (getprop("/engines/active-engine/running")) {
+            setprop("/controls/switches/starter", 0);
+            removelistener(engineRunning);
+        }
+    });
+
 };
 
 ##########################################

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -24,6 +24,8 @@ var autostart = func (msg=1) {
     setprop("/consumables/fuel/tank[0]/selected", 1);
     setprop("/consumables/fuel/tank[1]/selected", 1);
 
+    setprop("/controls/flight/flaps", 0.0);
+
     # Set the altimeter
     var pressure_sea_level = getprop("/environment/pressure-sea-level-inhg");
     setprop("/instrumentation/altimeter/setting-inhg", pressure_sea_level);
@@ -44,12 +46,16 @@ var autostart = func (msg=1) {
     setprop("/consumables/fuel/tank[1]/water-contamination", 0.0);        
 
     # Setting max oil level
-    if (getprop("/controls/engines/active-engine") == 0) {
-        setprop("/engines/active-engine/oil-level", 7.0);
-    } 
-    else {
-        setprop("/engines/active-engine/oil-level", 8.0);
-    };
+    var oil_enabled = getprop("/engines/active-engine/oil_consumption_allowed");
+    var oil_level   = getprop("/engines/active-engine/oil-level");
+    
+    if (oil_enabled and oil_level < 6.0)
+        if (getprop("/controls/engines/active-engine") == 0) {
+            setprop("/engines/active-engine/oil-level", 7.0);
+        } 
+        else {
+            setprop("/engines/active-engine/oil-level", 8.0);
+        };
 
     # Checking for minimal fuel level
     var fuel_level_left  = getprop("/consumables/fuel/tank[0]/level-norm");

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -181,8 +181,6 @@ var update = func {
 };
 
 setlistener("/controls/switches/starter", func {
-    if (!getprop("/fdm/jsbsim/complex"))
-        c172p.autostart(0);
     var v = getprop("/controls/switches/starter") or 0;
     if (v == 0) {
         print("Starter off");

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -718,6 +718,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <file>Aircraft/Generic/updateloop.nas</file>
         </updateloop>
         <c172p>
+            <file>Nasal/c172p.nas</file>
             <file>Nasal/liveries.nas</file>
             <file>Nasal/immat.nas</file>
             <file>Nasal/doors.nas</file>
@@ -730,7 +731,6 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <file>Nasal/flashlight.nas</file>
             <!-- Damage Mod -->
             <file>Nasal/physics.nas</file>
-            <file>Nasal/c172p.nas</file>
             <file>Nasal/tiedowns.nas</file>
         </c172p>
         <electrical>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -261,7 +261,6 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <path>/controls/climate-control/overhead-vent-front-left</path>
             <path>/controls/climate-control/overhead-vent-front-right</path>
             <path>/fdm/jsbsim/running</path>
-            <path>/fdm/jsbsim/complex</path>
             <path>/consumables/fuel/save-fuel-state</path>
             <path>/consumables/fuel/contamination_allowed</path>
             <path>/instrumentation/save-switches-state</path>
@@ -909,7 +908,6 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             </heat>
             <crash type="bool">false</crash>
             <running type="bool">false</running>
-            <complex type="bool">true</complex>
             <bushkit type="int">0</bushkit>
             <wing-damage>
                 <left-wing type="double">0.0</left-wing>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -78,16 +78,6 @@
                     <command>dialog-apply</command>
                 </binding>
             </checkbox>
-
-            <checkbox>
-                <halign>left</halign>
-                <label>Complex start up procedures</label>
-                <property>/fdm/jsbsim/complex</property>
-                <live>true</live>
-                <binding>
-                    <command>dialog-apply</command>
-                </binding>
-            </checkbox>
             
             <checkbox>
                 <halign>left</halign>

--- a/gui/dialogs/c172p-left-fuel.xml
+++ b/gui/dialogs/c172p-left-fuel.xml
@@ -42,7 +42,7 @@
             <slider>
                 <name>c172p-left-fuel-slider</name>
                 <min>0</min>
-                <max>28.0</max>
+                <max>21.5</max>
                 <live>true</live>
                 <enable>
                     <less-than>

--- a/gui/dialogs/c172p-right-fuel.xml
+++ b/gui/dialogs/c172p-right-fuel.xml
@@ -42,7 +42,7 @@
             <slider>
                 <name>c172p-right-fuel-slider</name>
                 <min>0</min>
-                <max>28.0</max>
+                <max>21.5</max>
                 <live>true</live>
                 <enable>
                     <less-than>


### PR DESCRIPTION
Closes #757 

- better autostart function: sets oil level to max, sets fuel to 25% for each tank if any of them is lower than 25% (min recommended for safely operating the 172), automatically crank and starts the engine
- removed the "complex engine" option from dialogs
- small fix to fuel dialogs: the max level was wrongly set to be 28 gal instead of 21.5 gal
- in the `c172p-set.xml` file, the nasal file `c172p.nas` is declared before all others so that in the future any of its functions may be called from the ones below