### PR TITLE
Bug 763: Property already defined bug

### DIFF
--- a/Systems/indicated-airspeed.xml
+++ b/Systems/indicated-airspeed.xml
@@ -42,8 +42,6 @@
     output shown on the ASI.
 -->
 
-    <property>/instrumentation/airspeed-indicator/indicated-speed-kt</property>
-
     <channel name="indicated airspeed">
 
         <fcs_function name="systems/asi/indicated-airspeed">

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -593,6 +593,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <pitch-offset-deg type="double">-2.7</pitch-offset-deg>
         </magnetic-compass>
         <airspeed-indicator>
+            <indicated-speed-kt type="int">0</indicated-speed-kt>
             <serviceable type="bool">false</serviceable> <!-- since pitot tube is on for the first time one runs this plane -->
         </airspeed-indicator>
         <save-switches-state type="bool">false</save-switches-state>


### PR DESCRIPTION
Fixes #763 

I'm guessing we still are OK with moving the creation of this property to the centralized location in the set?