### PR TITLE
Add securing=false to runup, takeoff, and taxiing tutorial.

### DIFF
--- a/Tutorials/runup.xml
+++ b/Tutorials/runup.xml
@@ -71,6 +71,26 @@ For more information on the before takeoff checklist, see Section 2-11 of the FA
             <property>/controls/engines/engine/primer</property>
             <value>4</value>
         </set>
+        <set>
+            <property>/sim/model/c172p/securing/chock</property>
+            <value>false</value>
+        </set>
+        <set>
+            <property>/sim/model/c172p/securing/tiedownL-visible</property>
+            <value>false</value>
+        </set>
+        <set>
+            <property>/sim/model/c172p/securing/tiedownR-visible</property>
+            <value>false</value>
+        </set>
+        <set>
+            <property>/sim/model/c172p/securing/tiedownT-visible</property>
+            <value>false</value>
+        </set>
+        <set>
+            <property>/sim/model/c172p/securing/pitot-cover-visible</property>
+            <value>false</value>
+        </set>
         <nasal>
             <script>
                 setprop("/controls/engines/current-engine/mixture", 1.0);

--- a/Tutorials/takeoff.xml
+++ b/Tutorials/takeoff.xml
@@ -75,6 +75,26 @@ This tutorial will teach you how to take-off from runway 13, and climb at 600 fe
             <property>/controls/engines/engine/primer</property>
             <value>4</value>
         </set>
+        <set>
+            <property>/sim/model/c172p/securing/chock</property>
+            <value>false</value>
+        </set>
+        <set>
+            <property>/sim/model/c172p/securing/tiedownL-visible</property>
+            <value>false</value>
+        </set>
+        <set>
+            <property>/sim/model/c172p/securing/tiedownR-visible</property>
+            <value>false</value>
+        </set>
+        <set>
+            <property>/sim/model/c172p/securing/tiedownT-visible</property>
+            <value>false</value>
+        </set>
+        <set>
+            <property>/sim/model/c172p/securing/pitot-cover-visible</property>
+            <value>false</value>
+        </set>
         <nasal>
             <script>
                 setprop("/controls/engines/current-engine/mixture", 1.0);

--- a/Tutorials/taxiing.xml
+++ b/Tutorials/taxiing.xml
@@ -88,6 +88,26 @@ For more information on taxiing, see Section 2-9 of the FAA Airplane Flying Hand
             <property>/controls/engines/engine/primer</property>
             <value>4</value>
         </set>
+        <set>
+            <property>/sim/model/c172p/securing/chock</property>
+            <value>false</value>
+        </set>
+        <set>
+            <property>/sim/model/c172p/securing/tiedownL-visible</property>
+            <value>false</value>
+        </set>
+        <set>
+            <property>/sim/model/c172p/securing/tiedownR-visible</property>
+            <value>false</value>
+        </set>
+        <set>
+            <property>/sim/model/c172p/securing/tiedownT-visible</property>
+            <value>false</value>
+        </set>
+        <set>
+            <property>/sim/model/c172p/securing/pitot-cover-visible</property>
+            <value>false</value>
+        </set>
         <nasal>
             <script>
                 setprop("/controls/engines/current-engine/mixture", 1.0);


### PR DESCRIPTION
Fixes issue #792 