### PR TITLE
Bug 795: External hotspots not clickable from cockpit any longer

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -7194,6 +7194,9 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/pitot-cover-removable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/pitot-cover"/>
@@ -7204,6 +7207,9 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/pitot-cover-removable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>remove-pitot-tube-cap</tooltip-id>
@@ -7220,6 +7226,12 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/pitot-cover-addable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/pitot-cover"/>
@@ -7235,6 +7247,9 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/pitot-cover-addable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>put-pitot-tube-cap</tooltip-id>
@@ -7340,6 +7355,11 @@
             <button>0</button>
             <repeatable>false</repeatable>
             <binding>
+                <condition>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
+                </condition>
                 <command>property-assign</command>
                 <property>/sim/model/c172p/securing/chock</property>
                 <value>false</value>
@@ -7349,6 +7369,9 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/chock</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>remove-wheel-chock</tooltip-id>
@@ -7366,6 +7389,9 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/chock-addable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>property-assign</command>
                 <property>sim/model/c172p/securing/chock</property>
@@ -7376,6 +7402,9 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/chock-addable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>secure-with-wheel-chock</tooltip-id>
@@ -7410,6 +7439,11 @@
             <button>0</button>
             <repeatable>false</repeatable>
             <binding>
+                <condition>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
+                </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/tiedowns/left/visible"/>
                 <value>false</value>
@@ -7419,6 +7453,9 @@
             <binding>
                 <condition>
                     <property alias="/params/securing/tiedowns/left/visible"/>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>remove-left-tiedowns</tooltip-id>
@@ -7431,6 +7468,9 @@
         <object-name>TiedownHotSpotLeft</object-name>
         <condition>
             <property>/sim/model/c172p/securing/tiedownL-addable</property>
+            <not>
+                <property>/sim/current-view/internal</property>
+            </not>
         </condition>
     </animation>
     <animation>
@@ -7442,6 +7482,9 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/tiedownL-addable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/tiedowns/left/visible"/>
@@ -7452,6 +7495,9 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/tiedownL-addable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>secure-with-left-tiedowns</tooltip-id>
@@ -7486,6 +7532,11 @@
             <button>0</button>
             <repeatable>false</repeatable>
             <binding>
+                <condition>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
+                </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/tiedowns/right/visible"/>
                 <value>false</value>
@@ -7495,6 +7546,9 @@
             <binding>
                 <condition>
                     <property alias="/params/securing/tiedowns/right/visible"/>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>remove-right-tiedowns</tooltip-id>
@@ -7507,6 +7561,9 @@
         <object-name>TiedownHotSpotRight</object-name>
         <condition>
             <property>/sim/model/c172p/securing/tiedownR-addable</property>
+            <not>
+                <property>/sim/current-view/internal</property>
+            </not>
         </condition>
     </animation>
     <animation>
@@ -7518,6 +7575,9 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/tiedownR-addable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/tiedowns/right/visible"/>
@@ -7528,6 +7588,9 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/tiedownR-addable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>secure-with-right-tiedowns</tooltip-id>
@@ -7562,6 +7625,11 @@
             <button>0</button>
             <repeatable>false</repeatable>
             <binding>
+                <condition>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
+                </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/tiedowns/tail/visible"/>
                 <value>false</value>
@@ -7571,6 +7639,9 @@
             <binding>
                 <condition>
                     <property alias="/params/securing/tiedowns/tail/visible"/>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>remove-tail-tiedowns</tooltip-id>
@@ -7583,6 +7654,9 @@
         <object-name>TiedownHotSpotTail</object-name>
         <condition>
             <property>/sim/model/c172p/securing/tiedownT-addable</property>
+            <not>
+                <property>/sim/current-view/internal</property>
+            </not>
         </condition>
     </animation>
     <animation>
@@ -7594,6 +7668,9 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/tiedownT-addable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/tiedowns/tail/visible"/>
@@ -7604,6 +7681,9 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/tiedownT-addable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>secure-with-tail-tiedowns</tooltip-id>
@@ -7872,6 +7952,18 @@
     
     <!-- Left Tank Drain Sump -->
     <animation>
+        <type>select</type>
+        <object-name>SumpHotSpotLeft</object-name>
+            <condition>
+                <and>
+                    <property>/consumables/fuel/contamination_allowed</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
+                </and>
+            </condition>
+    </animation>
+    <animation>
         <type>pick</type>
         <object-name>SumpHotSpotLeft</object-name>
         <visible>true</visible>
@@ -7899,6 +7991,18 @@
     </animation>
     
     <!-- Right Tank Drain Sump -->
+    <animation>
+        <type>select</type>
+        <object-name>SumpHotSpotRight</object-name>
+            <condition>
+                <and>
+                    <property>/consumables/fuel/contamination_allowed</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
+                </and>
+            </condition>
+    </animation>
     <animation>
         <type>pick</type>
         <object-name>SumpHotSpotRight</object-name>
@@ -7928,6 +8032,18 @@
     
     <!-- oil level check -->
     <animation>
+        <type>select</type>
+        <object-name>OilDoorHotSpot</object-name>
+            <condition>
+                <and>
+                    <property>/engines/active-engine/oil_consumption_allowed</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
+                </and>
+            </condition>
+    </animation>
+    <animation>
         <type>pick</type>
         <object-name>OilDoorHotSpot</object-name>
         <action>
@@ -7950,6 +8066,9 @@
                             <property>/controls/engines/active-engine</property>
                             <value>0</value>
                         </equals>
+                        <not>
+                            <property>/sim/current-view/internal</property>
+                        </not>
                     </and>
                 </condition>
                 <command>dialog-show</command>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -7229,9 +7229,6 @@
                     <not>
                         <property>/sim/current-view/internal</property>
                     </not>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/pitot-cover"/>


### PR DESCRIPTION
Closes: https://github.com/Juanvvc/c172p-detailed/issues/795

When pressing Ctrl+C, external hotspots do not show if they are hidden by the fuselage, but if you click in the correct position they do work (e.g. it's possible to open the oil dialog or add/remove chocks to the front wheel from the pilot's view).

This PR adds conditional for these so that they are only clickable if the view is external.
