### PR TITLE
Improving autostart function

### DIFF
--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -11,7 +11,7 @@ var autostart = func (msg=1) {
 
     setprop("/controls/switches/magnetos", 3);
     setprop("/controls/engines/current-engine/throttle", 0.2);
-    setprop("/controls/engines/current-engine/mixture", 1.0);
+    setprop("/controls/engines/current-engine/mixture", 0.95);
     setprop("/controls/flight/elevator-trim", 0.0);
     setprop("/controls/switches/master-bat", 1);
     setprop("/controls/switches/master-alt", 1);

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -73,18 +73,20 @@ var autostart = func (msg=1) {
     # All set, starting engine
     setprop("/controls/switches/starter", 1);
 
+    var engineRunning = setlistener("/engines/active-engine/running", func {
+        if (getprop("/engines/active-engine/running")) {
+            setprop("/controls/switches/starter", 0);
+            removelistener(engineRunning);
+        }
+    });        
+
     var engine_running_check_delay = 5.0;
     settimer(func {
         if (!getprop("/engines/active-engine/running")) {
             gui.popupTip("The autostart failed to start the engine. You must lean the mixture and start the engine manually.", 5);
             setprop("/controls/switches/starter", 0);
+            removelistener(engineRunning);
         }
-        var engineRunning = setlistener("/engines/active-engine/running", func {
-            if (getprop("/engines/active-engine/running")) {
-                setprop("/controls/switches/starter", 0);
-                removelistener(engineRunning);
-            }
-        });        
     }, engine_running_check_delay);
 
 };

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -72,12 +72,20 @@ var autostart = func (msg=1) {
 
     # All set, starting engine
     setprop("/controls/switches/starter", 1);
-    var engineRunning = setlistener("/engines/active-engine/running", func {
-        if (getprop("/engines/active-engine/running")) {
+
+    var engine_running_check_delay = 5.0;
+    settimer(func {
+        if (!getprop("/engines/active-engine/running")) {
+            gui.popupTip("The autostart failed to start the engine. You must lean the mixture and start the engine manually.", 5);
             setprop("/controls/switches/starter", 0);
-            removelistener(engineRunning);
         }
-    });
+        var engineRunning = setlistener("/engines/active-engine/running", func {
+            if (getprop("/engines/active-engine/running")) {
+                setprop("/controls/switches/starter", 0);
+                removelistener(engineRunning);
+            }
+        });        
+    }, engine_running_check_delay);
 
 };
 

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -163,7 +163,7 @@ var update = func {
     elsif (usePrimer and !engine_running and getprop("/engines/active-engine/oil-temperature-degf") <= 75) {
         # Mixture is controlled by start conditions
         var primer = getprop("/controls/engines/engine/primer");
-        if (!getprop("/fdm/jsbsim/fcs/mixture-primer") and getprop("/controls/switches/starter")) {
+        if (!getprop("/fdm/jsbsim/fcs/mixture-primer-cmd") and getprop("/controls/switches/starter")) {
             if (primer < 3) {
                 print("Use the primer!");
                 gui.popupTip("Use the primer!");

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -616,6 +616,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <kill-engine type="bool">false</kill-engine>
             <oil-level type="double">7.0</oil-level>
             <oil_consumption_allowed type="bool">false</oil_consumption_allowed>
+            <auto-start type="bool">false</auto-start>
         </active-engine>
 
         <!-- Following properties are part of a static list of properties

--- a/c172p.xml
+++ b/c172p.xml
@@ -915,7 +915,7 @@
             <!-- If the engine was primed enough times and throttle
                  is in starter position, then mixture is 1.
             -->
-            <fcs_function name="fcs/mixture-primer">
+            <fcs_function name="fcs/mixture-primer-cmd">
                 <function>
                     <table>
                         <independentVar lookup="row">/controls/engines/engine/primer</independentVar>
@@ -933,6 +933,16 @@
                 </function>
             </fcs_function>
 
+            <pure_gain name="fcs/mixture-primer[0]">
+                <input>fcs/mixture-cmd-norm[0]</input>
+                <gain>fcs/mixture-primer-cmd</gain>
+            </pure_gain>
+
+            <pure_gain name="fcs/mixture-primer[1]">
+                <input>fcs/mixture-cmd-norm[1]</input>
+                <gain>fcs/mixture-primer-cmd</gain>
+            </pure_gain>
+
             <!-- Primer logic for 160 HP engine -->
             <switch name="Mixture Position 160 HP">
                 <default value="fcs/mixture-cmd-norm[0]"/>
@@ -940,7 +950,7 @@
                 <!-- Use primer if used and engine is cold. If engine
                      is warm, then the mixture lever is used.
                 -->
-                <test logic="AND" value="fcs/mixture-primer">
+                <test logic="AND" value="fcs/mixture-primer[0]">
                     /controls/engines/engine/use-primer eq 1
                     /engines/engine[0]/oil-temperature-degf le 75
                 </test>
@@ -953,7 +963,7 @@
                 <!-- Use primer if used and engine is cold. If engine
                      is warm, then the mixture lever is used.
                 -->
-                <test logic="AND" value="fcs/mixture-primer">
+                <test logic="AND" value="fcs/mixture-primer[1]">
                     /controls/engines/engine/use-primer eq 1
                     /engines/engine[1]/oil-temperature-degf le 75
                 </test>


### PR DESCRIPTION
Closes #791 

This function should work better than before, and it should start the plane even at low pressure environments. If the autostart function does not succeed in starting the engine within 5 seconds, it will give up and show an error message. This will happen at very high and very low pressure airfields, and the user is then instructed to manually start the engine.