### PR TITLE
Primer tooltip

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -2015,7 +2015,8 @@
             <binding>
                 <command>set-tooltip</command>
                 <tooltip-id>primer</tooltip-id>
-                <label>Engine primer</label>
+                <label>Engine primer (%1d)</label>
+                <property>controls/engines/engine/primer</property>
             </binding>
         </hovered>
     </animation>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -374,6 +374,7 @@
                         <command>nasal</command>
                         <script>
                             setprop("/controls/engines/active-engine", 0);
+                            setprop("controls/engines/engine/primer", 0);
                             setprop("sim/model/c172p/engine_flag_0", 1);
                             setprop("sim/model/c172p/engine_flag_1", 0);
                         </script>
@@ -406,6 +407,7 @@
                         <command>nasal</command>
                         <script>
                             setprop("/controls/engines/active-engine", 1);
+                            setprop("controls/engines/engine/primer", 0);
                             setprop("sim/model/c172p/engine_flag_0", 0);
                             setprop("sim/model/c172p/engine_flag_1", 1);
                         </script>
@@ -465,6 +467,7 @@
 
                                 # Select 160 HP engine
                                 setprop("/controls/engines/active-engine", 0);
+                                setprop("controls/engines/engine/primer", 0);
                                 setprop("sim/model/c172p/engine_flag_0", 1);
                                 setprop("sim/model/c172p/engine_flag_1", 0);
                             </script>
@@ -497,6 +500,7 @@
 
                                 # Select 160 HP engine
                                 setprop("/controls/engines/active-engine", 0);
+                                setprop("controls/engines/engine/primer", 0);
                                 setprop("sim/model/c172p/engine_flag_0", 1);
                                 setprop("sim/model/c172p/engine_flag_1", 0);
                             </script>
@@ -529,6 +533,7 @@
 
                                 # Select 160 HP engine
                                 setprop("/controls/engines/active-engine", 0);
+                                setprop("controls/engines/engine/primer", 0);
                                 setprop("sim/model/c172p/engine_flag_0", 1);
                                 setprop("sim/model/c172p/engine_flag_1", 0);
                             </script>
@@ -565,6 +570,7 @@
 
                                 # Select 180 HP engine
                                 setprop("/controls/engines/active-engine", 1);
+                                setprop("controls/engines/engine/primer", 0);
                                 setprop("sim/model/c172p/engine_flag_0", 0);
                                 setprop("sim/model/c172p/engine_flag_1", 1);
                             </script>
@@ -617,6 +623,7 @@
 
                                 # Select 180 HP engine
                                 setprop("/controls/engines/active-engine", 1);
+                                setprop("controls/engines/engine/primer", 0);
                                 setprop("sim/model/c172p/engine_flag_0", 0);
                                 setprop("sim/model/c172p/engine_flag_1", 1);
                             </script>
@@ -654,6 +661,7 @@
 
                                 # Select 180 HP engine
                                 setprop("/controls/engines/active-engine", 1);
+                                setprop("controls/engines/engine/primer", 0);
                                 setprop("sim/model/c172p/engine_flag_0", 0);
                                 setprop("sim/model/c172p/engine_flag_1", 1);
                             </script>


### PR DESCRIPTION
Closes #807 

This PR changes the primer tooltip, so that hovering above the primer shows how many strokes have been made so far. Also, the primer is reset now when the engine or landing gear configuration changes.