### PR TITLE
Battery

### DIFF
--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -448,6 +448,11 @@ var log_fog_frost = func {
 };
 var fog_frost_timer = maketimer(30.0, log_fog_frost);
 
+var dialog_battery_reload = func {
+    electrical.reset_battery_and_circuit_breakers();
+    gui.popupTip("The battery is now fully charged!");
+}
+
 setlistener("/sim/signals/fdm-initialized", func {
     # Use Nasal to make some properties persistent. <aircraft-data> does
     # not work reliably.

--- a/Nasal/electrical.nas
+++ b/Nasal/electrical.nas
@@ -67,7 +67,7 @@ BatteryClass.new = func {
                 ideal_volts : 24.0,
                 ideal_amps : 30.0,
                 amp_hours : 12.75,
-                charge_percent : 1.0,
+                charge_percent : getprop("/systems/electrical/battery-charge-percent") or 1.0,
                 charge_amps : 7.0 };
     setprop("/systems/electrical/battery-charge-percent", obj.charge_percent);
     return obj;
@@ -79,7 +79,7 @@ BatteryClass.new = func {
 #
 
 BatteryClass.apply_load = func (amps, dt) {
-    var old_charge_percent = getprop("/systems/electrical/battery-charge-percent");
+    var old_charge_percent = me.charge_percent;
 
     if (getprop("/sim/freeze/replay-state"))
         return me.amp_hours * old_charge_percent;
@@ -90,8 +90,8 @@ BatteryClass.apply_load = func (amps, dt) {
     var new_charge_percent = std.max(0.0, std.min(old_charge_percent - percent_used, 1.0));
 
     if (new_charge_percent < 0.1 and old_charge_percent >= 0.1)
-        gui.popupTip("Warning: Low battery! Enable alternator or apply external power to recharge battery!", 10);
-
+        gui.popupTip("Warning: Low battery! Enable alternator or apply external power to recharge battery!", 10);       
+    me.charge_percent = new_charge_percent;
     setprop("/systems/electrical/battery-charge-percent", new_charge_percent);
     return me.amp_hours * new_charge_percent;
 }

--- a/Nasal/electrical.nas
+++ b/Nasal/electrical.nas
@@ -71,7 +71,7 @@ BatteryClass.new = func {
     var obj = { parents : [BatteryClass],
                 ideal_volts : 24.0,
                 ideal_amps : 30.0,
-                amp_hours : 12.75,
+                amp_hours : 25.00,
                 charge_percent : getprop("/systems/electrical/battery-charge-percent") or 1.0,
                 charge_amps : 7.0 };
     setprop("/systems/electrical/battery-charge-percent", obj.charge_percent);

--- a/Nasal/electrical.nas
+++ b/Nasal/electrical.nas
@@ -71,7 +71,7 @@ BatteryClass.new = func {
     var obj = { parents : [BatteryClass],
                 ideal_volts : 24.0,
                 ideal_amps : 30.0,
-                amp_hours : 25.00,
+                amp_hours : 3.1875,
                 charge_percent : getprop("/systems/electrical/battery-charge-percent") or 1.0,
                 charge_amps : 7.0 };
     setprop("/systems/electrical/battery-charge-percent", obj.charge_percent);
@@ -357,7 +357,7 @@ var electrical_bus_1 = func() {
             # starter
             if ( getprop("controls/switches/starter") ) {
                 setprop("systems/electrical/outputs/starter", bus_volts);
-                load += 12;
+                load += 24;
             } else {
                 setprop("systems/electrical/outputs/starter", 0.0);
             }

--- a/Nasal/electrical.nas
+++ b/Nasal/electrical.nas
@@ -31,6 +31,11 @@ var init_electrical = func {
     # Request that the update function be called next frame
     settimer(update_electrical, 0);
     print("Electrical system initialized");
+    
+    # checking if battery should be automatically recharged
+    if (!getprop("/systems/electrical/save-battery-charge")) {    
+        battery.reset_to_full_charge();
+    };   
 }
 
 var reset_battery_and_circuit_breakers = func {

--- a/Nasal/electrical.nas
+++ b/Nasal/electrical.nas
@@ -84,7 +84,7 @@ BatteryClass.new = func {
 #
 
 BatteryClass.apply_load = func (amps, dt) {
-    var old_charge_percent = me.charge_percent;
+    var old_charge_percent = getprop("/systems/electrical/battery-charge-percent");
 
     if (getprop("/sim/freeze/replay-state"))
         return me.amp_hours * old_charge_percent;
@@ -95,7 +95,7 @@ BatteryClass.apply_load = func (amps, dt) {
     var new_charge_percent = std.max(0.0, std.min(old_charge_percent - percent_used, 1.0));
 
     if (new_charge_percent < 0.1 and old_charge_percent >= 0.1)
-        gui.popupTip("Warning: Low battery! Enable alternator or apply external power to recharge battery!", 10);       
+        gui.popupTip("Warning: Low battery! Enable alternator or apply external power to recharge battery!", 10);
     me.charge_percent = new_charge_percent;
     setprop("/systems/electrical/battery-charge-percent", new_charge_percent);
     return me.amp_hours * new_charge_percent;

--- a/Systems/electrical.xml
+++ b/Systems/electrical.xml
@@ -8,7 +8,6 @@
         <input>
             <property>/systems/electrical/battery-charge-percent</property> <!-- this property ranges from 0.0 to 1.0 despite its name -->
         </input>
-        <reference>0.0</reference>
         <output>
             <property>/systems/electrical/battery-charge-percent-100</property>
         </output>

--- a/Systems/electrical.xml
+++ b/Systems/electrical.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<PropertyList>
+
+    <filter>
+        <type>gain</type>
+        <gain>100.0</gain>
+        <input>
+            <property>/systems/electrical/battery-charge-percent</property> <!-- this property ranges from 0.0 to 1.0 despite its name -->
+        </input>
+        <reference>0.0</reference>
+        <output>
+            <property>/systems/electrical/battery-charge-percent-100</property>
+        </output>
+    </filter>
+
+</PropertyList>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -346,6 +346,10 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <property-rule n="107">
                 <path>Aircraft/c172p/Systems/sounds.xml</path>
             </property-rule>
+            
+            <property-rule n="108">
+                <path>Aircraft/c172p/Systems/electrical.xml</path>
+            </property-rule>
         </systems>
 
         <sound>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -271,6 +271,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <path>/instrumentation/save-switches-state</path>
             <path>/consumables/fuel/tank[0]/level-gal_us</path>
             <path>/consumables/fuel/tank[1]/level-gal_us</path>
+            <path>/systems/electrical/battery-charge-percent</path>
         </aircraft-data>
 
         <current-view>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -271,6 +271,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <path>/instrumentation/save-switches-state</path>
             <path>/consumables/fuel/tank[0]/level-gal_us</path>
             <path>/consumables/fuel/tank[1]/level-gal_us</path>
+            <path>/systems/electrical/save-battery-charge</path>
             <path>/systems/electrical/battery-charge-percent</path>
         </aircraft-data>
 
@@ -944,9 +945,13 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 
     <systems>
         <electrical>
+        
             <outputs>
                 <flaps type="double">0.0</flaps>
             </outputs>
+            
+            <save-battery-charge type="bool">false</save-battery-charge>
+            
         </electrical>
     </systems>
 

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -161,6 +161,29 @@
 
         <group>
             <layout>vbox</layout>
+
+            <button>
+                <halign>center</halign>
+                <legend>Recharge battery</legend>
+                <binding>
+                    <command>nasal</command>
+                    <script>c172p.dialog_battery_reload();</script>
+                </binding>
+            </button>
+    
+            <text>
+                <label>Current charge is xxxx %%</label>
+                <format>Current charge is %3.1f %%</format>
+                <live>true</live>
+                <property>/systems/electrical/battery-charge-percent-100</property>
+            </text>
+            
+        </group>
+
+        <hrule/>
+
+        <group>
+            <layout>vbox</layout>
             
             <checkbox>
                 <halign>left</halign>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -91,6 +91,16 @@
             
             <checkbox>
                 <halign>left</halign>
+                <label>Save battery charge between sessions</label>
+                <property>/systems/electrical/save-battery-charge</property>
+                <live>true</live>
+                <binding>
+                    <command>dialog-apply</command>
+                </binding>
+            </checkbox>
+            
+            <checkbox>
+                <halign>left</halign>
                 <label>Save positions of all switches between sessions</label>
                 <property>/instrumentation/save-switches-state</property>
                 <live>true</live>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -170,24 +170,24 @@
         <hrule/>
 
         <group>
-            <layout>vbox</layout>
+            <layout>hbox</layout>
+
+            <text>
+                <halign>left</halign>
+                <label>Battery charge: xxxx %%</label>
+                <format>Battery charge: %3.1f %%</format>
+                <live>true</live>
+                <property>/systems/electrical/battery-charge-percent-100</property>
+            </text>
 
             <button>
-                <halign>center</halign>
+                <halign>right</halign>
                 <legend>Recharge battery</legend>
                 <binding>
                     <command>nasal</command>
                     <script>c172p.dialog_battery_reload();</script>
                 </binding>
-            </button>
-    
-            <text>
-                <label>Current charge is xxxx %%</label>
-                <format>Current charge is %3.1f %%</format>
-                <live>true</live>
-                <property>/systems/electrical/battery-charge-percent-100</property>
-            </text>
-            
+            </button>               
         </group>
 
         <hrule/>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -152,14 +152,29 @@
 
             <button>
                 <halign>right</halign>
-                <legend>Repair</legend>
+                <legend>Repair</legend>                
                 <pref-width>60</pref-width>
                 <pref-height>28</pref-height>
-                <visible>
-                    <not>
-                        <property>/sim/freeze/replay-state</property>
-                    </not>
-                </visible>
+                <enable>
+                    <and>
+                        <not>
+                            <property>/sim/freeze/replay-state</property>
+                        </not>
+                        <or>
+                            <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
+                            <property>/fdm/jsbsim/hydro/active-norm</property>
+                        </or>
+                        <less-than>
+                            <property>velocities/groundspeed-kt</property>
+                            <value>1.0</value>
+                        </less-than>
+                        <not>
+                            <property>/engines/active-engine/running</property>
+                        </not>
+                    </and>
+                </enable>
                 <binding>
                     <command>nasal</command>
                     <script>c172p.repair_damage();electrical.reset_battery_and_circuit_breakers();c172p.click("engine-repair", 6.0)</script>
@@ -183,6 +198,26 @@
             <button>
                 <halign>right</halign>
                 <legend>Recharge battery</legend>
+                <enable>
+                    <and>
+                        <not>
+                            <property>/sim/freeze/replay-state</property>
+                        </not>
+                        <or>
+                            <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                            <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
+                            <property>/fdm/jsbsim/hydro/active-norm</property>
+                        </or>
+                        <less-than>
+                            <property>velocities/groundspeed-kt</property>
+                            <value>1.0</value>
+                        </less-than>
+                        <not>
+                            <property>/engines/active-engine/running</property>
+                        </not>
+                    </and>
+                </enable>
                 <binding>
                     <command>nasal</command>
                     <script>c172p.dialog_battery_reload();</script>


### PR DESCRIPTION
This PR closes #801, and possibly #36, ~~37 and 38~~ (please confirm it)

- aircraft dialog show battery charge in percentage
- aircraft dialog has a recharge battery button
- battery charge is now persistent among sessions
- the user can disable the option above (that is, every time the sim is loaded it also sets the battery charge to 100%)
- battery voltage now drains! Before it was always stuck at 24.5 due to a mistake at the `electrical.nas`
- aircraft starter won't work if the battery is too low (to test it, turn the master ON and let the battery drain using simulation acceleration by pressing `a` several times)