### PR TITLE
fixing issue with buttons

### DIFF
--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -160,12 +160,6 @@
                         <not>
                             <property>/sim/freeze/replay-state</property>
                         </not>
-                        <or>
-                            <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
-                            <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
-                            <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
-                            <property>/fdm/jsbsim/hydro/active-norm</property>
-                        </or>
                         <less-than>
                             <property>velocities/groundspeed-kt</property>
                             <value>1.0</value>
@@ -203,12 +197,6 @@
                         <not>
                             <property>/sim/freeze/replay-state</property>
                         </not>
-                        <or>
-                            <property>/fdm/jsbsim/gear/unit[1]/WOW</property>
-                            <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
-                            <property>/fdm/jsbsim/gear/unit[23]/WOW</property>
-                            <property>/fdm/jsbsim/hydro/active-norm</property>
-                        </or>
                         <less-than>
                             <property>velocities/groundspeed-kt</property>
                             <value>1.0</value>


### PR DESCRIPTION
Closes #814 

Repair and Recharge Battery buttons in the Aircraft Menu should now work when the aircraft has crashed