### PR TITLE
Setting full rotation to vol knobs of kx165

### DIFF
--- a/Models/Interior/Panel/Instruments/kx165/kx165-1.xml
+++ b/Models/Interior/Panel/Instruments/kx165/kx165-1.xml
@@ -570,7 +570,7 @@
     <type>knob</type>
     <object-name>CommVolume</object-name>
     <property alias="../../params/comm-volume"/>
-    <factor>-65</factor>
+    <factor>-250</factor>
     <axis>
       <x>1</x>
       <y>0</y>
@@ -778,7 +778,7 @@
     <type>knob</type>
     <object-name>NavVolume</object-name>
     <property alias="../../params/nav-volume"/>
-    <factor>-65</factor>
+    <factor>-250</factor>
     <axis>
       <x>1</x>
       <y>0</y>

--- a/Models/Interior/Panel/Instruments/kx165/kx165-2.xml
+++ b/Models/Interior/Panel/Instruments/kx165/kx165-2.xml
@@ -570,7 +570,7 @@
     <type>knob</type>
     <object-name>CommVolume</object-name>
     <property alias="../../params/comm-volume"/>
-    <factor>-65</factor>
+    <factor>-250</factor>
     <axis>
       <x>1</x>
       <y>0</y>
@@ -778,7 +778,7 @@
     <type>knob</type>
     <object-name>NavVolume</object-name>
     <property alias="../../params/nav-volume"/>
-    <factor>-65</factor>
+    <factor>-250</factor>
     <axis>
       <x>1</x>
       <y>0</y>


### PR DESCRIPTION
Closes #819 

Setting full rotation to vol knobs of kx165, see issue above for more details. This is the new position for full volume (100%):

![fg](https://cloud.githubusercontent.com/assets/5700795/17564701/a43b093c-5f34-11e6-994f-aea1e54df0c1.jpg)
