### PR TITLE
Kr87 knob now works while the sim is paused

### DIFF
--- a/Models/Interior/Panel/Instruments/kr87-adf/kr87.xml
+++ b/Models/Interior/Panel/Instruments/kr87-adf/kr87.xml
@@ -246,31 +246,20 @@
     </animation>
 
     <animation>
+        <type>select</type>
+        <object-name>indicator.Stby.1000</object-name>
         <condition>
             <greater-than-equals>
-                <property alias="../../../../params/right-display"/>
+                <property>/instrumentation/adf[0]/frequencies/standby-khz</property>
                 <value type="int">1000</value>
             </greater-than-equals>
         </condition>
-        <type>select</type>
-        <object-name>indicator.Stby.1000</object-name>
     </animation>
 
     <animation>
-        <condition>
-            <greater-than-equals>
-                <property alias="../../../../params/right-display"/>
-                <value type="int">100</value>
-            </greater-than-equals>
-        </condition>
-        <type>select</type>
-        <object-name>indicator.Stby.100</object-name>
-    </animation>
-    
-    <animation>
         <type>textranslate</type>
         <object-name>indicator.Stby.1000</object-name>
-        <property alias="../../params/right-display"/>
+        <property>/instrumentation/adf[0]/frequencies/standby-khz</property>
         <step>1000</step>
         <factor>0.0001</factor>
         <axis>
@@ -283,7 +272,7 @@
     <animation>
         <type>textranslate</type>
         <object-name>indicator.Stby.100</object-name>
-        <property alias="../../params/right-display"/>
+        <property>/instrumentation/adf[0]/frequencies/standby-khz</property>
         <step>100</step>
         <factor>0.001</factor>
         <axis>
@@ -296,7 +285,7 @@
     <animation>
         <type>textranslate</type>
         <object-name>indicator.Stby.10</object-name>
-        <property alias="../../params/right-display"/>
+        <property>/instrumentation/adf[0]/frequencies/standby-khz</property>
         <step>10</step>
         <factor>0.01</factor>
         <axis>
@@ -309,7 +298,7 @@
     <animation>
         <type>textranslate</type>
         <object-name>indicator.Stby.1</object-name>
-        <property alias="../../params/right-display"/>
+        <property>/instrumentation/adf[0]/frequencies/standby-khz</property>
         <step>1</step>
         <factor>0.1</factor>
         <axis>
@@ -318,7 +307,6 @@
             <z>0</z>
         </axis>
     </animation>
-
 
     <!-- knobs and buttons -->
     <animation>


### PR DESCRIPTION
Closes #401 

Now ADF frequency knobs (inner and outer) as well as the swap frequency button work while the sim is paused