### PR TITLE
Illumination intensity and radiance effect on/by radio stack

### DIFF
--- a/Models/Interior/Panel/Instruments/kt76a/kt76a.xml
+++ b/Models/Interior/Panel/Instruments/kt76a/kt76a.xml
@@ -98,9 +98,9 @@
         <object-name>Ident</object-name>
         <object-name>Ident-light</object-name>
         <emission>
-            <red>0.5</red>
-            <green>0.1</green>
-            <blue>0.00005</blue>
+            <red>0.6</red>
+            <green>0.25</green>
+            <blue>0.00025</blue>
             <factor-prop>/sim/model/c172p/lighting/trans</factor-prop>
         </emission>
     </animation>

--- a/Models/Interior/Panel/Instruments/kx165/kx165-1.xml
+++ b/Models/Interior/Panel/Instruments/kx165/kx165-1.xml
@@ -224,9 +224,9 @@
             </and>
         </condition>
         <emission>
-            <red>1.0</red>
-            <green>1.0</green>
-            <blue>1.0</blue>
+            <red>0.91</red>
+            <green>0.91</green>
+            <blue>0.91</blue>
             <factor-prop>/sim/model/c172p/lighting/comm0</factor-prop>
         </emission>
     </animation>

--- a/Models/Interior/Panel/Instruments/kx165/kx165-2.xml
+++ b/Models/Interior/Panel/Instruments/kx165/kx165-2.xml
@@ -224,9 +224,9 @@
             </and>
         </condition>
         <emission>
-            <red>1.0</red>
-            <green>1.0</green>
-            <blue>1.0</blue>
+            <red>0.91</red>
+            <green>0.91</green>
+            <blue>0.91</blue>
             <factor-prop>/sim/model/c172p/lighting/comm1</factor-prop>
         </emission>
     </animation>

--- a/Systems/als-lights.xml
+++ b/Systems/als-lights.xml
@@ -204,16 +204,33 @@
         <type>gain</type>
         <gain>0.010</gain>
         <input>
-            <expression>
-                <product>
-                    <sum>
-                        <property>/sim/model/c172p/lighting/comm0</property>
-                        <property>/sim/model/c172p/lighting/comm1</property>
-                        <property>/sim/model/c172p/lighting/adf</property>
-                    </sum>
+            <condition>
+                <greater-than>
                     <property>/controls/lighting/radio-norm</property>
-                </product>
+                    <value>0.0</value>
+                </greater-than>
+            </condition>
+            <expression>
+                <sum>
+                    <property>/sim/model/c172p/lighting/comm0</property>
+                    <property>/sim/model/c172p/lighting/comm1</property>
+                    <property>/sim/model/c172p/lighting/adf</property>
+                </sum>
             </expression>
+        </input>
+        <input>
+            <condition>
+                <and>
+                    <equals>
+                        <property>/controls/lighting/radio-norm</property>
+                        <value>0.0</value>
+                    </equals>
+                    <property>/sim/model/c172p/lighting/comm0-power</property>
+                    <property>/sim/model/c172p/lighting/comm1-power</property>
+                    <property>/instrumentation/adf[0]/operable</property>
+                </and>
+            </condition>
+            <value>3.0</value>
         </input>
         <output>
             <property>/sim/model/c172p/lighting/inst-r-norm</property>
@@ -225,17 +242,34 @@
         <type>gain</type>
         <gain>0.006</gain>
         <input>
-            <expression>
-                <product>
-                    <sum>
-                        <property>/sim/model/c172p/lighting/comm0</property>
-                        <property>/sim/model/c172p/lighting/comm1</property>
-                        <property>/sim/model/c172p/lighting/adf</property>
-                    </sum>
+            <condition>
+                <greater-than>
                     <property>/controls/lighting/radio-norm</property>
-                </product>
+                    <value>0.0</value>
+                </greater-than>
+            </condition>
+            <expression>
+                <sum>
+                    <property>/sim/model/c172p/lighting/comm0</property>
+                    <property>/sim/model/c172p/lighting/comm1</property>
+                    <property>/sim/model/c172p/lighting/adf</property>
+                </sum>
             </expression>
         </input>
+        <input>
+            <condition>
+                <and>
+                    <equals>
+                        <property>/controls/lighting/radio-norm</property>
+                        <value>0.0</value>
+                    </equals>
+                    <property>/sim/model/c172p/lighting/comm0-power</property>
+                    <property>/sim/model/c172p/lighting/comm1-power</property>
+                    <property>/instrumentation/adf[0]/operable</property>
+                </and>
+            </condition>
+            <value>3.0</value>
+        </input>   
         <output>
             <property>/sim/model/c172p/lighting/inst-g-norm</property>
         </output>
@@ -246,16 +280,33 @@
         <type>gain</type>
         <gain>0.006</gain>
         <input>
-            <expression>
-                <product>
-                    <sum>
-                        <property>/sim/model/c172p/lighting/comm0</property>
-                        <property>/sim/model/c172p/lighting/comm1</property>
-                        <property>/sim/model/c172p/lighting/adf</property>
-                    </sum>
+            <condition>
+                <greater-than>
                     <property>/controls/lighting/radio-norm</property>
-                </product>
+                    <value>0.0</value>
+                </greater-than>
+            </condition>
+            <expression>
+                <sum>
+                    <property>/sim/model/c172p/lighting/comm0</property>
+                    <property>/sim/model/c172p/lighting/comm1</property>
+                    <property>/sim/model/c172p/lighting/adf</property>
+                </sum>
             </expression>
+        </input>
+        <input>
+            <condition>
+                <and>
+                    <equals>
+                        <property>/controls/lighting/radio-norm</property>
+                        <value>0.0</value>
+                    </equals>
+                    <property>/sim/model/c172p/lighting/comm0-power</property>
+                    <property>/sim/model/c172p/lighting/comm1-power</property>
+                    <property>/instrumentation/adf[0]/operable</property>
+                </and>
+            </condition>
+            <value>3.0</value>
         </input>
         <output>
             <property>/sim/model/c172p/lighting/inst-b-norm</property>


### PR DESCRIPTION
Closes #770 

This PR does the following:

- makes the digits of both COMMs and NAVs digital displays less bright, so they look more similar to the AP, DME and ADF
- uses better conditionals for the radiance effect by the COMMS, NAVs and ADF radios: before if the radio illumination was set to 0%, there was no radiance effect even though that's the position in which the displays are at maximum intensity (daylight mode). So now they take that into consideration
- the conditional also removes a `<product>` from `<expression>` which was making the radiance effect appear in an exponential factor that looks bad and made no sense to me
- better colour for transponder ident and ident button backlight, makes them look more similar to the orange hue of the other digits (as opposed to the dark full red hue they had before)

To test I suggest the following:

- obviously test at night
- slowly move the radio lights from 5% to 100% and notice how the digits of all instruments have the same intensity, and also confirm the radiance FX is ok
- toggle the radio lights between 5% and 0% (daylight mode) and notice a huge change in the radiance FX
- test that the radiance FX goes away when battery is off or volume of the comms is 0%