### PR TITLE
Bug 30: Hide most instruments further than 25 m and radio stack 60 m

### DIFF
--- a/Models/Interior/Panel/Instruments/EGT/EGT.xml
+++ b/Models/Interior/Panel/Instruments/EGT/EGT.xml
@@ -32,12 +32,6 @@
   </params>
 
   <animation>
-    <type>range</type>
-    <min-m>0</min-m>
-    <max-m>10</max-m>
-  </animation>
-  
-  <animation>
     <type>material</type>
     <object-name>Needle</object-name>
     <object-name>Bug</object-name>

--- a/Models/Interior/Panel/Instruments/kr87-adf/ki227_228.xml
+++ b/Models/Interior/Panel/Instruments/kr87-adf/ki227_228.xml
@@ -32,13 +32,6 @@
   </animation>
 
   <animation>
-    <type>range</type>
-    <min-m>0</min-m>
-    <max-m>10</max-m>
-  </animation>
-
-  
-  <animation>
     <type>material</type>
     <object-name>CompassRose</object-name>
     <object-name>KI227.ADFNeedle</object-name>

--- a/Models/Interior/Panel/Instruments/kr87-adf/kr87.xml
+++ b/Models/Interior/Panel/Instruments/kr87-adf/kr87.xml
@@ -77,11 +77,6 @@
     <animation>
         <type>noshadow</type>
     </animation>
-    <animation>
-        <type>range</type>
-        <min-m>0</min-m>
-        <max-m>10</max-m>
-    </animation>
 
     <animation>
         <type>material</type>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -1956,10 +1956,8 @@
         <object-name>CarbHeatBack</object-name>
         <object-name>CarbHeatRod</object-name>
     </animation>
-    <!-- <animation>
+    <animation>
         <name>ControlsGroup</name>
-        <object-name>PanelInstruments</object-name>
-        <object-name>ElectronicsGroup</object-name>
         <object-name>LeftYoke</object-name>
         <object-name>RightYoke</object-name>
         <object-name>CarbHeatGroup</object-name>
@@ -1967,13 +1965,10 @@
         <object-name>Mixture</object-name>
         <object-name>FlapSwitchGroup</object-name>
         <object-name>TrimWheel</object-name>
-    </animation> -->
-    <!-- <animation>
-        <type>range</type>
-        <object-name>ControlsGroup</object-name>
-        <min-m>0</min-m>
-        <max-m>10.0</max-m>
-    </animation> -->
+        <object-name>PilotPedals</object-name>
+        <object-name>CoPilotPedals</object-name>
+        <object-name>MagCompass</object-name>
+    </animation>
 
     <!-- MOD: animation for the checklists -->
     <animation>
@@ -3370,19 +3365,47 @@
 
     <!-- Interior -->
     <animation>
-        <name>InteriorGroup</name>
-        <object-name>Cabin</object-name>
-        <object-name>Panel</object-name>
-        <object-name>PilotSeat</object-name>
-        <object-name>CopilotSeat</object-name>
-        <object-name>BackSeat</object-name>
-        <object-name>MagCompass</object-name>
+        <name>InstrumentsGroup</name>
+        <!-- Note: excluding AI and Turn because they are clearly visible even from a distance -->
+        <object-name>Gear</object-name>
+        <object-name>Altimeter</object-name>
+        <object-name>BatteryGauge</object-name>
+        <object-name>Kap140</object-name>
+        <object-name>dme</object-name>
+        <object-name>asi</object-name>
+        <object-name>VSI</object-name>
+        <object-name>RPM</object-name>
+        <object-name>EGT</object-name>
+        <object-name>hi</object-name>
+        <object-name>avor</object-name>
+        <object-name>vor2</object-name>
+        <object-name>adf</object-name>
+        <object-name>clock</object-name>
+        <object-name>vac</object-name>
+        <object-name>fuel</object-name>
+        <object-name>oil</object-name>
+        <object-name>BreakersAndAvionicsSwitch</object-name>
+    </animation>
+    <animation>
+        <name>RadioGroup</name>
+        <object-name>kx165-1</object-name>
+        <object-name>kx165-2</object-name>
+        <object-name>kma20</object-name>
+        <object-name>kr87</object-name>
+        <object-name>transponder</object-name>
     </animation>
     <animation>
         <type>range</type>
-        <object-name>InteriorGroup</object-name>
+        <object-name>InstrumentsGroup</object-name>
+        <object-name>ControlsGroup</object-name>
         <min-m>0</min-m>
-        <max-m>50</max-m>
+        <max-m>25</max-m>
+    </animation>
+    <animation>
+        <type>range</type>
+        <object-name>RadioGroup</object-name>
+        <min-m>0</min-m>
+        <max-m>60</max-m>
     </animation>
 
     <!-- Airframe -->
@@ -6195,11 +6218,6 @@
     </animation>
     <!-- End Damage Mod -->
 
-    <animation>
-        <type>range</type>
-        <min-m>0</min-m>
-        <max-m>25000</max-m>
-    </animation>
     <Plane.014Xparams>
         <light-near>0.8</light-near>
         <light-med>3.2</light-med>
@@ -6326,11 +6344,6 @@
         <condition>
             <property alias="/params/lighting/beacon"/>
         </condition>
-    </animation>
-    <animation>
-        <type>range</type>
-        <min-m>0</min-m>
-        <max-m>25000</max-m>
     </animation>
     <BeaconOffXparams>
         <light-near>0.4</light-near>


### PR DESCRIPTION
Fixes #30

Most instruments can be hidden at range higher than 25 meter. The radio stack is hidden beyond 60 meter because it shows a distinguishable gray background.