### PR TITLE
carburetor icing and carburetor heat 

### DIFF
--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -58,7 +58,7 @@ var autostart = func (msg=1) {
         };
     };
 
-    # removig any ice from the carburetor
+    # removing any ice from the carburetor
     setprop("/engines/active-engine/carb_ice", 0.0);
     setprop("/engines/active-engine/carb_icing_rate", 0.0);
     setprop("/engines/active-engine/volumetric-efficiency-factor", 1.0);

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -58,6 +58,11 @@ var autostart = func (msg=1) {
         };
     };
 
+    # removig any ice from the carburetor
+    setprop("/engines/active-engine/carb_ice", 0.0);
+    setprop("/engines/active-engine/carb_icing_rate", 0.0);
+    setprop("/engines/active-engine/volumetric-efficiency-factor", 1.0);
+
     # Checking for minimal fuel level
     var fuel_level_left  = getprop("/consumables/fuel/tank[0]/level-norm");
     var fuel_level_right = getprop("/consumables/fuel/tank[1]/level-norm");

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -135,7 +135,7 @@ var carb_icing_function = maketimer(1.0, func {
         var airtempC = getprop("/environment/temperature-degc");        
         var factorX = 13.2 - 3.2 * math.atan2 ( ((rpm - 2000.0) * 0.008), 1);
         var factorY = 7.0 - 2.0 * math.atan2 ( ((rpm - 2000.0) * 0.008), 1);  
-        var carb_icing_rate = math.exp( math.pow((0.8 * airtempC + 0.2 * dewpointC - 45.0),2) / (-2 * math.pow(factorX,2))) * math.exp( math.pow((0.2 * airtempC - 0.8 * dewpointC + 28.0),2) / (-2 * math.pow(factorY,2)));                
+        var carb_icing_rate = math.exp( math.pow((0.6 * airtempC + 0.15 * dewpointC - 32.0),2) / (-2 * math.pow(factorX,2))) * math.exp( math.pow((0.15 * airtempC - 0.6 * dewpointC + 18.0),2) / (-2 * math.pow(factorY,2))) - 0.2;        
         
         # if carb heat on, the rate decreses by a certain amount
         if (getprop("/engines/active-engine/running") and getprop("/controls/engines/current-engine/carb-heat"))
@@ -148,11 +148,14 @@ var carb_icing_function = maketimer(1.0, func {
             carb_ice = 0.0;
         if (carb_ice > 1.0)
             carb_ice = 1.0;
+            
         setprop("/engines/active-engine/carb_ice", carb_ice);
+        setprop("/engines/active-engine/carb_icing_rate", carb_icing_rate);
+        
     } 
     else {
-        var carb_ice = 0.0;
-        setprop("/engines/active-engine/carb_ice", carb_ice);
+        setprop("/engines/active-engine/carb_ice", 0.0);
+        setprop("/engines/active-engine/carb_icing_rate", 0.0);
     }; 
 });
 

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -149,18 +149,12 @@ var carb_icing_function = maketimer(1.0, func {
         
         # carb icing rate is multiplied by an oil temp factor so a cold engine doens't accumulate ice
         var oil_temp_factor = (oil_temp - 120) / 100;
-        if (oil_temp_factor < 0.0)
-            oil_temp_factor = 0.0;
-        if (oil_temp_factor > 1.0)
-            oil_temp_factor = 1.0;
+        oil_temp_factor = std.max(0.0, std.min(oil_temp_factor, 1.0));
         var carb_icing_rate = oil_temp_factor * (carb_icing_formula + carb_heat_rate);
 
         var carb_ice = getprop("/engines/active-engine/carb_ice");
         carb_ice = carb_ice + carb_icing_rate;
-        if (carb_ice < 0.0)
-            carb_ice = 0.0;
-        if (carb_ice > 1.0)
-            carb_ice = 1.0;
+        carb_ice = std.max(0.0, std.min(carb_ice, 1.0));
 
         # this property is used to lower the RPM of the engine as ice accumulates
         var vol_eff_factor = 1.0 - 2.218 * carb_ice;
@@ -175,6 +169,7 @@ var carb_icing_function = maketimer(1.0, func {
         setprop("/engines/active-engine/carb_ice", 0.0);
         setprop("/engines/active-engine/carb_icing_rate", 0.0);
         setprop("/engines/active-engine/volumetric-efficiency-factor", 1.0);
+        setprop("/engines/active-engine/oil_temp_factor", 0.0);
     };
 });
 

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -134,22 +134,29 @@ var carb_icing_function = maketimer(1.0, func {
         var dewpointC = getprop("/environment/dewpoint-degc");
         var dewpointF = dewpointC * 9.0 / 5.0 + 32;
         var airtempF = getprop("/environment/temperature-degf");
-        var egt_temp = getprop("/engines/active-engine/egt-norm");
+        var oil_temp = getprop("/engines/active-engine/oil-temperature-degf");
         
         # the formula below attempts to modle the graph found in the POH, using RPM, airtempF and dewpointF as variables
         var factorX = 13.2 - 3.2 * math.atan2 ( ((rpm - 2000.0) * 0.008), 1);
         var factorY = 7.0 - 2.0 * math.atan2 ( ((rpm - 2000.0) * 0.008), 1);
-        var carb_icing_rate = 0.01 * (math.exp( math.pow((0.6 * airtempF + 0.3 * dewpointF - 42.0),2) / (-2 * math.pow(factorX,2))) * math.exp( math.pow((0.3 * airtempF - 0.6 * dewpointF + 14.0),2) / (-2 * math.pow(factorY,2))) - 0.2);
-
+        var carb_icing_formula = 0.01 * (math.exp( math.pow((0.6 * airtempF + 0.3 * dewpointF - 42.0),2) / (-2 * math.pow(factorX,2))) * math.exp( math.pow((0.3 * airtempF - 0.6 * dewpointF + 14.0),2) / (-2 * math.pow(factorY,2))) - 0.2);
+        
         # if carb heat on, the rate decreses by a certain amount
         if (getprop("/engines/active-engine/running") and getprop("/controls/engines/current-engine/carb-heat"))
-            var carb_heat_rate = -0.03 * egt_temp;
+            var carb_heat_rate = -0.01;
         else
             var carb_heat_rate = 0.0;
+        
+        # carb icing rate is multiplied by an oil temp factor so a cold engine doens't accumulate ice
+        var oil_temp_factor = (oil_temp - 120) / 100;
+        if (oil_temp_factor < 0.0)
+            oil_temp_factor = 0.0;
+        if (oil_temp_factor > 1.0)
+            oil_temp_factor = 1.0;
+        var carb_icing_rate = oil_temp_factor * (carb_icing_formula + carb_heat_rate);
 
         var carb_ice = getprop("/engines/active-engine/carb_ice");
-        # carb icing rate is multiplied by EGT temp so a cold engine at 0 RPM doens't accumulate ice
-        carb_ice = carb_ice + carb_icing_rate * egt_temp + carb_heat_rate;
+        carb_ice = carb_ice + carb_icing_rate;
         if (carb_ice < 0.0)
             carb_ice = 0.0;
         if (carb_ice > 1.0)
@@ -161,6 +168,7 @@ var carb_icing_function = maketimer(1.0, func {
         setprop("/engines/active-engine/carb_ice", carb_ice);
         setprop("/engines/active-engine/carb_icing_rate", carb_icing_rate);
         setprop("/engines/active-engine/volumetric-efficiency-factor", vol_eff_factor);
+        setprop("/engines/active-engine/oil_temp_factor", oil_temp_factor);
 
     }
     else {

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -138,9 +138,8 @@ var carb_icing_function = maketimer(1.0, func {
         var carb_icing_rate = math.exp( math.pow((0.8 * airtempC + 0.2 * dewpointC - 45.0),2) / (-2 * math.pow(factorX,2))) * math.exp( math.pow((0.2 * airtempC - 0.8 * dewpointC + 28.0),2) / (-2 * math.pow(factorY,2)));                
         
         # if carb heat on, the rate decreses by a certain amount
-        var carb_heat = getprop("/controls/engines/current-engine/carb-heat");
-        if (carb_heat)
-            carb_icing_rate = carb_icing_rate - 0.01;            
+        if (getprop("/engines/active-engine/running") and getprop("/controls/engines/current-engine/carb-heat"))
+            carb_icing_rate = carb_icing_rate - 0.01;
         
         # changing in carb ice according to the rate calculated above
         var carb_ice = getprop("/engines/active-engine/carb_ice");               

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -155,13 +155,18 @@ var carb_icing_function = maketimer(1.0, func {
         if (carb_ice > 1.0)
             carb_ice = 1.0;
 
+        # this property is used to lower the RPM of the engine as ice accumulates
+        var vol_eff_factor = 1.0 - 2.218 * carb_ice;
+
         setprop("/engines/active-engine/carb_ice", carb_ice);
         setprop("/engines/active-engine/carb_icing_rate", carb_icing_rate);
+        setprop("/engines/active-engine/volumetric-efficiency-factor", vol_eff_factor);
 
     }
     else {
         setprop("/engines/active-engine/carb_ice", 0.0);
         setprop("/engines/active-engine/carb_icing_rate", 0.0);
+        setprop("/engines/active-engine/volumetric-efficiency-factor", 1.0);
     };
 });
 

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -593,9 +593,6 @@
         <name>Engine 160 HP Carb Icing Factor</name>
         <type>gain</type>
         <input>
-            <condition>
-                <property>/engines/active-engine/carb_icing_allowed</property>
-            </condition>
             <property>/engines/active-engine/volumetric-efficiency-factor</property>
         </input>
         <output>
@@ -607,9 +604,6 @@
         <name>Engine 180 HP Carb Icing Factor</name>
         <type>gain</type>
         <input>
-            <condition>
-                <property>/engines/active-engine/carb_icing_allowed</property>
-            </condition>
             <property>/engines/active-engine/volumetric-efficiency-factor</property>
         </input>
         <output>

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -506,6 +506,10 @@
                     <property>/engines/active-engine/oil-level</property>
                     <value>4.92</value>
                 </less-than>
+                <greater-than-equals>
+                    <property>/engines/active-engine/carb_ice</property>
+                    <value>0.32</value>
+                </greater-than-equals>
             </or>
         </input>
         <output>
@@ -562,6 +566,16 @@
                     <less-than>
                         <property>/engines/active-engine/oil-level</property>
                         <value>4.925</value>
+                    </less-than>
+                </and>
+                <and>
+                    <greater-than-equals>
+                        <property>/engines/active-engine/carb_ice</property>
+                        <value>0.3</value>
+                    </greater-than-equals>
+                    <less-than>
+                        <property>/engines/active-engine/carb_ice</property>
+                        <value>0.32</value>
                     </less-than>
                 </and>
             </or>

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -584,5 +584,37 @@
             <property>/engines/active-engine/coughing</property>
         </output>
     </logic>
+    
+    <!-- ============================================================== -->
+    <!-- Carburetor Icing drops RPM                                     -->
+    <!-- ============================================================== -->
+
+    <filter>
+        <name>Engine 160 HP Carb Icing Factor</name>
+        <type>gain</type>
+        <input>
+            <condition>
+                <property>/engines/active-engine/carb_icing_allowed</property>
+            </condition>
+            <property>/engines/active-engine/volumetric-efficiency-factor</property>
+        </input>
+        <output>
+            <property>/fdm/jsbsim/propulsion/engine[0]/volumetric-efficiency</property>
+        </output>
+    </filter>
+
+    <filter>
+        <name>Engine 180 HP Carb Icing Factor</name>
+        <type>gain</type>
+        <input>
+            <condition>
+                <property>/engines/active-engine/carb_icing_allowed</property>
+            </condition>
+            <property>/engines/active-engine/volumetric-efficiency-factor</property>
+        </input>
+        <output>
+            <property>/fdm/jsbsim/propulsion/engine[1]/volumetric-efficiency</property>
+        </output>
+    </filter>            
 
 </PropertyList>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -631,6 +631,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <oil-level type="double">7.0</oil-level>
             <oil_consumption_allowed type="bool">false</oil_consumption_allowed>
             <carb_ice type="double">0.0</carb_ice>
+            <carb_icing_rate type="double">0.0</carb_icing_rate>
             <carb_icing_allowed type="bool">false</carb_icing_allowed>
             <auto-start type="bool">false</auto-start>
         </active-engine>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -259,6 +259,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <path>/sim/model/c172p/brake-parking</path>
             <path>/sim/model/c172p/enable-fog-frost</path>
             <path>/sim/model/c172p/garmin196-visible</path>
+            <path>/engines/active-engine/carb_icing_allowed</path>
             <path>/engines/active-engine/oil_consumption_allowed</path>
             <path>/engines/active-engine/oil-level</path>
             <path>/fdm/jsbsim/settings/damage</path>
@@ -629,6 +630,8 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <kill-engine type="bool">false</kill-engine>
             <oil-level type="double">7.0</oil-level>
             <oil_consumption_allowed type="bool">false</oil_consumption_allowed>
+            <carb_ice type="double">0.0</carb_ice>
+            <carb_icing_allowed type="bool">false</carb_icing_allowed>
             <auto-start type="bool">false</auto-start>
         </active-engine>
 

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -133,6 +133,21 @@
                     <command>dialog-apply</command>
                 </binding>
             </checkbox>
+            
+            <checkbox>
+                <halign>left</halign>
+                <label>Allow carburetor icing</label>
+                <property>/engines/active-engine/carb_icing_allowed</property>
+                <live>true</live>
+                <binding>
+                    <command>property-assign</command>
+                    <property>/engines/active-engine/oil-level</property>
+                    <value>7.0</value>
+                </binding>
+                <binding>
+                    <command>dialog-apply</command>
+                </binding>
+            </checkbox>
         </group>
 
         <hrule/>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -186,7 +186,33 @@
                 </enable>
                 <binding>
                     <command>nasal</command>
-                    <script>c172p.repair_damage();electrical.reset_battery_and_circuit_breakers();c172p.click("engine-repair", 6.0)</script>
+                    <script>
+                        c172p.repair_damage();
+                        electrical.reset_battery_and_circuit_breakers();
+                        c172p.click("engine-repair", 6.0);
+                        c172p.dialog_battery_reload();
+                    </script>
+                </binding>
+                <binding>
+                    <condition>
+                        <property>sim/model/c172p/engine_flag_0</property>
+                    </condition>
+                    <command>property-assign</command>
+                    <property>/engines/active-engine/oil-level</property>
+                    <value>7.0</value>
+                </binding>
+                <binding>
+                    <condition>
+                        <property>sim/model/c172p/engine_flag_1</property>
+                    </condition>
+                    <command>property-assign</command>
+                    <property>/engines/active-engine/oil-level</property>
+                    <value>8.0</value>
+                </binding>
+                <binding>
+                    <command>property-assign</command>
+                    <property>/engines/active-engine/carb_ice</property>
+                    <value>0.0</value>
                 </binding>
             </button>
         </group>


### PR DESCRIPTION
Fixes #360 

A first attempt to model carburetor icing and carburetor heat. Before merging, please test _extensively_ to make sure this doesn't break anything. Also, I think we should keep issue 360 opened since both @onox and I agree that this implementation here isn't really the best approach.

For testing: first of all, go to the aircraft menu and enable carb icing.

Then play with the weather:  go to the weather menu, select High Pressure scenario but do not apply, then select Manual and play around with the values `20/08` in the METAR string, the first being the temp in Celsius the second being the dew point in Celsius. The closer they are the more humidity there is in the air. Then compare with the chart below (in Fahrenheit!):

![](https://cloud.githubusercontent.com/assets/5700795/11609309/e6d8c92a-9b83-11e5-9c37-06e8c17cc6e6.png)

The accumulation of ice is given by the property `/engines/active-engine/carb_ice`. When it reaches `0.3` the engine starts coughing and at `0.32` it turns off. The icing rate is given by `/engines/active-engine/carb_icing_rate` times the EGT temp (so that a cold and not running engine does not accumulate ice like crazy at 0 RPM). The effectiveness of the carburetor heat is also proportional to the EGT temp.

Situations with temp and dew point at `07/07` cause _a lot_ of ice build up. But when the temps are outside the orange and green part of the graph above the ice should slowly melt.

:warning: :warning: :warning: 

Before merging: I would still like to make the RPM of the engine drop as the ice accumulates, so that the engine is perfectly healthy when  `/engines/active-engine/carb_ice` is at `0.0` but quite weak when  `/engines/active-engine/carb_ice` is at around `0.3`. Can anyone advice me how can I do this? I wanted to use a filter, but I can't find which property should I use on it. @onox any ideas?