### PR TITLE
Fixing console error message when changing engines

### DIFF
--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -436,13 +436,17 @@
                         </script>
                     </binding>
                     <binding>
-                        <command>property-assign</command>
-                        <property>/engines/active-engine/oil-level</property>
-                        <value>7.0</value>
+                        <command>dialog-show</command>
+                        <dialog-name>c172p-oil-dialog-180</dialog-name>
                     </binding>
                     <binding>
                         <command>dialog-close</command>
                         <dialog-name>c172p-oil-dialog-180</dialog-name>
+                    </binding>
+                    <binding>
+                        <command>property-assign</command>
+                        <property>/engines/active-engine/oil-level</property>
+                        <value>7.0</value>
                     </binding>
                 </radio>
 
@@ -469,13 +473,17 @@
                         </script>
                     </binding>
                     <binding>
-                        <command>property-assign</command>
-                        <property>/engines/active-engine/oil-level</property>
-                        <value>8.0</value>
+                        <command>dialog-show</command>
+                        <dialog-name>c172p-oil-dialog-160</dialog-name>
                     </binding>
                     <binding>
                         <command>dialog-close</command>
                         <dialog-name>c172p-oil-dialog-160</dialog-name>
+                    </binding>
+                    <binding>
+                        <command>property-assign</command>
+                        <property>/engines/active-engine/oil-level</property>
+                        <value>8.0</value>
                     </binding>
                 </radio>
             </group>
@@ -528,6 +536,19 @@
                                 setprop("sim/model/c172p/engine_flag_1", 0);
                             </script>
                         </binding>
+                        <binding>
+                            <command>dialog-show</command>
+                            <dialog-name>c172p-oil-dialog-180</dialog-name>
+                        </binding>
+                        <binding>
+                            <command>dialog-close</command>
+                            <dialog-name>c172p-oil-dialog-180</dialog-name>
+                        </binding>
+                        <binding>
+                            <command>property-assign</command>
+                            <property>/engines/active-engine/oil-level</property>
+                            <value>7.0</value>
+                        </binding>
                     </radio>
 
                     <radio>
@@ -561,6 +582,19 @@
                                 setprop("sim/model/c172p/engine_flag_1", 0);
                             </script>
                         </binding>
+                        <binding>
+                            <command>dialog-show</command>
+                            <dialog-name>c172p-oil-dialog-180</dialog-name>
+                        </binding>
+                        <binding>
+                            <command>dialog-close</command>
+                            <dialog-name>c172p-oil-dialog-180</dialog-name>
+                        </binding>
+                        <binding>
+                            <command>property-assign</command>
+                            <property>/engines/active-engine/oil-level</property>
+                            <value>7.0</value>
+                        </binding>
                     </radio>
 
                     <radio>
@@ -593,6 +627,19 @@
                                 setprop("sim/model/c172p/engine_flag_0", 1);
                                 setprop("sim/model/c172p/engine_flag_1", 0);
                             </script>
+                        </binding>
+                        <binding>
+                            <command>dialog-show</command>
+                            <dialog-name>c172p-oil-dialog-180</dialog-name>
+                        </binding>
+                        <binding>
+                            <command>dialog-close</command>
+                            <dialog-name>c172p-oil-dialog-180</dialog-name>
+                        </binding>
+                        <binding>
+                            <command>property-assign</command>
+                            <property>/engines/active-engine/oil-level</property>
+                            <value>7.0</value>
                         </binding>
                     </radio>
                 </group>
@@ -651,6 +698,19 @@
                             <property>sim/model/c172p/securing/tiedownT-visible</property>
                             <value>false</value>
                         </binding>
+                        <binding>
+                            <command>dialog-show</command>
+                            <dialog-name>c172p-oil-dialog-160</dialog-name>
+                        </binding>
+                        <binding>
+                            <command>dialog-close</command>
+                            <dialog-name>c172p-oil-dialog-160</dialog-name>
+                        </binding>
+                        <binding>
+                            <command>property-assign</command>
+                            <property>/engines/active-engine/oil-level</property>
+                            <value>8.0</value>
+                        </binding>
                     </radio>
 
                     <radio>
@@ -689,6 +749,19 @@
                             <property>sim/model/c172p/securing/chock</property>
                             <value>false</value>
                         </binding>
+                        <binding>
+                            <command>dialog-show</command>
+                            <dialog-name>c172p-oil-dialog-160</dialog-name>
+                        </binding>
+                        <binding>
+                            <command>dialog-close</command>
+                            <dialog-name>c172p-oil-dialog-160</dialog-name>
+                        </binding>
+                        <binding>
+                            <command>property-assign</command>
+                            <property>/engines/active-engine/oil-level</property>
+                            <value>8.0</value>
+                        </binding>
                     </radio>
 
                     <radio>
@@ -726,6 +799,19 @@
                             <command>property-assign</command>
                             <property>sim/model/c172p/securing/chock</property>
                             <value>false</value>
+                        </binding>
+                        <binding>
+                            <command>dialog-show</command>
+                            <dialog-name>c172p-oil-dialog-160</dialog-name>
+                        </binding>
+                        <binding>
+                            <command>dialog-close</command>
+                            <dialog-name>c172p-oil-dialog-160</dialog-name>
+                        </binding>
+                        <binding>
+                            <command>property-assign</command>
+                            <property>/engines/active-engine/oil-level</property>
+                            <value>8.0</value>
                         </binding>
                     </radio>
                 </group>


### PR DESCRIPTION
Closes #827 

When changing between the 160 HP and 180 HP engines, the user would get the following error:

`Failed to execute command dialog-close`

This is because of how the oil dialogs was handled. See the issue above for the explanation of what caused it and how this fix work