### PR TITLE
lowering engine sound offsets

### DIFF
--- a/c172-sound.xml
+++ b/c172-sound.xml
@@ -24,7 +24,7 @@
                 <property>/sim/model/c172p/sound/volume-boost-doors</property>
             </volume>
             <volume>
-                <offset>0.4</offset>
+                <offset>0.0592</offset>
             </volume>
             <reference-dist>5.0</reference-dist>
             <max-dist>200.0</max-dist>
@@ -50,7 +50,7 @@
                 <property>/sim/model/c172p/sound/volume-boost-doors</property>
             </volume>
             <volume>
-                <offset>0.5</offset>
+                <offset>0.0592</offset>
             </volume>
             <reference-dist>5.0</reference-dist>
             <max-dist>200.0</max-dist>
@@ -70,7 +70,7 @@
                 <property>/sim/model/c172p/sound/volume-boost-doors</property>
             </volume>
             <volume>
-                <offset>0.3</offset>
+                <offset>0.0592</offset>
             </volume>
             <reference-dist>5.0</reference-dist>
             <max-dist>200.0</max-dist>
@@ -90,7 +90,7 @@
                 <property>/sim/model/c172p/sound/volume-boost-doors</property>
             </volume>
             <volume>
-                <offset>0.3</offset>
+                <offset>0.0592</offset>
             </volume>
             <reference-dist>5.0</reference-dist>
             <max-dist>200.0</max-dist>


### PR DESCRIPTION
Closes #776

It turned out I had to lower the offset of the engine sounds quite a bit now, since opening the windows and doors raise the volume and it starts clipping again. I also tried to activate all other sounds of our plane (repair, crash, doors, knobs, switches, etc.) and I tested all of them with both doors and windows opened, and it looks like there are no more clipping issues. I suggest whomever test this to do the same (remember to use ` --log-level=debug` when testing).

Also, given that the engine sounds were lowered a bit, we might have to consider doing the same for the other sounds of our plane. That said, it all sounded fine to me, so I am fine with merging this as it is.