### PR TITLE
Autostart handles battery charge locally

### DIFF
--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -9,8 +9,32 @@ var autostart = func (msg=1) {
         return;
     }
 
-    electrical.reset_battery_and_circuit_breakers();
+    # Filling fuel tanks
+    setprop("/consumables/fuel/tank[0]/selected", 1);
+    setprop("/consumables/fuel/tank[1]/selected", 1);
 
+    # Reset battery charge
+    setprop("/systems/electrical/battery-charge-percent", 1.0);
+    
+    # Reset circuit breakers
+    setprop("/controls/circuit-breakers/master", 1);
+    setprop("/controls/circuit-breakers/flaps", 1);
+    setprop("/controls/circuit-breakers/pitot-heat", 1);
+    setprop("/controls/circuit-breakers/instr", 1);
+    setprop("/controls/circuit-breakers/intlt", 1);
+    setprop("/controls/circuit-breakers/navlt", 1);
+    setprop("/controls/circuit-breakers/landing", 1);
+    setprop("/controls/circuit-breakers/bcnlt", 1);
+    setprop("/controls/circuit-breakers/strobe", 1);
+    setprop("/controls/circuit-breakers/turn-coordinator", 1);
+    setprop("/controls/circuit-breakers/radio1", 1);
+    setprop("/controls/circuit-breakers/radio2", 1);
+    setprop("/controls/circuit-breakers/radio3", 1);
+    setprop("/controls/circuit-breakers/radio4", 1);
+    setprop("/controls/circuit-breakers/radio5", 1);
+    setprop("/controls/circuit-breakers/autopilot", 1);
+
+    # Setting levers and switches for startup
     setprop("/controls/switches/magnetos", 3);
     setprop("/controls/engines/current-engine/throttle", 0.2);
     setprop("/controls/engines/current-engine/mixture", 0.95);
@@ -19,13 +43,12 @@ var autostart = func (msg=1) {
     setprop("/controls/switches/master-alt", 1);
     setprop("/controls/switches/master-avionics", 1);
 
+    # Setting lights
     setprop("/controls/lighting/nav-lights", 1);
     setprop("/controls/lighting/strobe", 1);
     setprop("/controls/lighting/beacon", 1);
 
-    setprop("/consumables/fuel/tank[0]/selected", 1);
-    setprop("/consumables/fuel/tank[1]/selected", 1);
-
+    # Setting flaps to 0
     setprop("/controls/flight/flaps", 0.0);
 
     # Set the altimeter
@@ -44,6 +67,7 @@ var autostart = func (msg=1) {
     setprop("/sim/model/c172p/securing/tiedownR-visible", 0);
     setprop("/sim/model/c172p/securing/tiedownT-visible", 0);
 
+    # Removing any contamination from water
     setprop("/consumables/fuel/tank[0]/water-contamination", 0.0);
     setprop("/consumables/fuel/tank[1]/water-contamination", 0.0);        
 

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -9,30 +9,12 @@ var autostart = func (msg=1) {
         return;
     }
 
+    # Reset battery charge and circuit breakers
+    electrical.reset_battery_and_circuit_breakers();
+
     # Filling fuel tanks
     setprop("/consumables/fuel/tank[0]/selected", 1);
     setprop("/consumables/fuel/tank[1]/selected", 1);
-
-    # Reset battery charge
-    setprop("/systems/electrical/battery-charge-percent", 1.0);
-    
-    # Reset circuit breakers
-    setprop("/controls/circuit-breakers/master", 1);
-    setprop("/controls/circuit-breakers/flaps", 1);
-    setprop("/controls/circuit-breakers/pitot-heat", 1);
-    setprop("/controls/circuit-breakers/instr", 1);
-    setprop("/controls/circuit-breakers/intlt", 1);
-    setprop("/controls/circuit-breakers/navlt", 1);
-    setprop("/controls/circuit-breakers/landing", 1);
-    setprop("/controls/circuit-breakers/bcnlt", 1);
-    setprop("/controls/circuit-breakers/strobe", 1);
-    setprop("/controls/circuit-breakers/turn-coordinator", 1);
-    setprop("/controls/circuit-breakers/radio1", 1);
-    setprop("/controls/circuit-breakers/radio2", 1);
-    setprop("/controls/circuit-breakers/radio3", 1);
-    setprop("/controls/circuit-breakers/radio4", 1);
-    setprop("/controls/circuit-breakers/radio5", 1);
-    setprop("/controls/circuit-breakers/autopilot", 1);
 
     # Setting levers and switches for startup
     setprop("/controls/switches/magnetos", 3);


### PR DESCRIPTION
Closes #838 

This PR makes changes to the autostart function:
- it now handles battery charge and circuit breakers locally instead of calling a function from electrical.nas. The issue was that when the option of starting the sim with engines on was toggled, the autostart function was being called before the electrical system was initialized. I did not manage to force it to initialize before the c172p.nas, but on top of that doing so could have caused more bugs. Doing things locally looks far more elegant in my opinion (though the original battery recharging function should stay there as it's used by one of the GUI dialogs)
- changed the order of some lines in the autostart function to make it more logical to a reader. E.g. checking for fuel level and battery charge is now done before setting the magnetos
- added more comments to make the function even clearer