### PR TITLE
Fixing small bugs (carb icing and oil)

### DIFF
--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -89,10 +89,16 @@ var primerTimer = maketimer(5, func {
 # ========== oil consumption ======================
 
 var oil_consumption = maketimer(1.0, func {
-    if (getprop("/engines/active-engine/oil_consumption_allowed"))
-        var oil_level = getprop("/engines/active-engine/oil-level");
-    else
-        var oil_level = 7.0;
+    if (!getprop("/engines/active-engine/oil_consumption_allowed")) {
+        if (getprop("/controls/engines/active-engine") == 0) {
+            setprop("/engines/active-engine/oil-level", 7.0);
+        } 
+        else {
+            setprop("/engines/active-engine/oil-level", 8.0);
+        };
+    };
+    
+    var oil_level = getprop("/engines/active-engine/oil-level");
     var rpm = getprop("/engines/active-engine/rpm");
 
     # Quadratic formula which outputs 1.0 for input 2300 RPM (cruise value),

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -125,11 +125,6 @@
                 <property>/engines/active-engine/oil_consumption_allowed</property>
                 <live>true</live>
                 <binding>
-                    <command>property-assign</command>
-                    <property>/engines/active-engine/oil-level</property>
-                    <value>7.0</value>
-                </binding>
-                <binding>
                     <command>dialog-apply</command>
                 </binding>
             </checkbox>
@@ -139,11 +134,6 @@
                 <label>Allow carburetor icing</label>
                 <property>/engines/active-engine/carb_icing_allowed</property>
                 <live>true</live>
-                <binding>
-                    <command>property-assign</command>
-                    <property>/engines/active-engine/oil-level</property>
-                    <value>7.0</value>
-                </binding>
                 <binding>
                     <command>dialog-apply</command>
                 </binding>


### PR DESCRIPTION
Fixing small bugs:

- enabling/disabling carb icing or oil management used to reset oil level to 7 quarts
- the oil function has been improved, so how disabling oil management will automatically set the oil to the max level for that specific engine (7 quarts for 160 hp and 8 quarts for 180 hp)
- starting the sim with oil management disabled will also set the engine to the correct amount of oil now

@dany93 thanks for spotting these issues (see https://github.com/Juanvvc/c172p-detailed/issues/851), let me know if these are now fixed