### PR TITLE
Consumed oil weight and a few bug fixes on full oil vs the engine.

### DIFF
--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -92,6 +92,10 @@ var oil_consumption = maketimer(1.0, func {
     if (getprop("/engines/active-engine/oil_consumption_allowed")) {
         var oil_level = getprop("/engines/active-engine/oil-level");
         var oil_consumed = getprop("/engines/active-engine/oil-consumed");
+        if (getprop("/controls/engines/active-engine") == 0)
+            var oil_full = 7;
+        if (getprop("/controls/engines/active-engine") == 1)
+            var oil_full = 8;
     
         var rpm = getprop("/engines/active-engine/rpm");
     
@@ -112,6 +116,9 @@ var oil_consumption = maketimer(1.0, func {
             setprop("/engines/active-engine/oil-level", oil_level);
             setprop("/engines/active-engine/oil-consumed", oil_consumed);
         }
+
+        var oil_lacking = oil_full - oil_level;
+        setprop("/engines/active-engine/oil-lacking", oil_lacking);
     
         # If oil gets low (< 5.0), pressure should drop and temperature should rise
         var oil_level_limited = std.min(oil_level, 5.0);

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -89,41 +89,50 @@ var primerTimer = maketimer(5, func {
 # ========== oil consumption ======================
 
 var oil_consumption = maketimer(1.0, func {
-    if (getprop("/engines/active-engine/oil_consumption_allowed"))
+    if (getprop("/engines/active-engine/oil_consumption_allowed")) {
         var oil_level = getprop("/engines/active-engine/oil-level");
-    else
-        var oil_level = 7.0;
-    var rpm = getprop("/engines/active-engine/rpm");
-
-    # Quadratic formula which outputs 1.0 for input 2300 RPM (cruise value),
-    # 0.6 for 700 RPM (idle) and 1.2 for 2700 RPM (max)
-    var rpm_factor = 0.00000012 * math.pow(rpm, 2) - 0.0001 * rpm + 0.62;
-
-    # Consumption rate defined as 1.5 quarter per 10 hours (36000 seconds)
-    # at cruise RPM
-    var consumption_rate = 1.5 / 36000; 
-
-    var low_oil_pressure_factor = 1.0;
-    var low_oil_temperature_factor = 1.0;
-
-    if (getprop("/engines/active-engine/running")) {
-        oil_level = oil_level - consumption_rate * rpm_factor;
-        setprop("/engines/active-engine/oil-level", oil_level);        
+        var oil_consumed = getprop("/engines/active-engine/oil-consumed");
+    
+        var rpm = getprop("/engines/active-engine/rpm");
+    
+        # Quadratic formula which outputs 1.0 for input 2300 RPM (cruise value),
+        # 0.6 for 700 RPM (idle) and 1.2 for 2700 RPM (max)
+        var rpm_factor = 0.00000012 * math.pow(rpm, 2) - 0.0001 * rpm + 0.62;
+    
+        # Consumption rate defined as 1.5 quarter per 10 hours (36000 seconds)
+        # at cruise RPM
+        var consumption_rate = 1.5 / 36000; 
+    
+        var low_oil_pressure_factor = 1.0;
+        var low_oil_temperature_factor = 1.0;
+    
+        if (getprop("/engines/active-engine/running")) {
+            oil_consumed = oil_consumed + consumption_rate * rpm_factor;     
+            oil_level = oil_level - consumption_rate * rpm_factor;
+            setprop("/engines/active-engine/oil-level", oil_level);
+            setprop("/engines/active-engine/oil-consumed", oil_consumed);
+        }
+    
+        # If oil gets low (< 5.0), pressure should drop and temperature should rise
+        var oil_level_limited = std.min(oil_level, 5.0);
+    
+        # Should give 1.0 for oil_level = 5 and 0.1 for oil_level 4.92,
+        # which is the min before the engine stops
+        low_oil_pressure_factor = 11.25 * oil_level_limited - 55.25;
+    
+        # Should give 1.0 for oil_level = 5 and 1.5 for oil_level 4.92
+        low_oil_temperature_factor = -6.25 * oil_level_limited + 32.25;
+    
+        setprop("/engines/active-engine/low-oil-pressure-factor", low_oil_pressure_factor);
+        setprop("/engines/active-engine/low-oil-temperature-factor", low_oil_temperature_factor);
     }
 
-    # If oil gets low (< 5.0), pressure should drop and temperature should rise
-    var oil_level_limited = std.min(oil_level, 5.0);
-
-    # Should give 1.0 for oil_level = 5 and 0.1 for oil_level 4.92,
-    # which is the min before the engine stops
-    low_oil_pressure_factor = 11.25 * oil_level_limited - 55.25;
-
-    # Should give 1.0 for oil_level = 5 and 1.5 for oil_level 4.92
-    low_oil_temperature_factor = -6.25 * oil_level_limited + 32.25;
-
-    setprop("/engines/active-engine/low-oil-pressure-factor", low_oil_pressure_factor);
-    setprop("/engines/active-engine/low-oil-temperature-factor", low_oil_temperature_factor);
-
+    else {
+        if (getprop("/controls/engines/active-engine") == 0)
+            setprop("/engines/active-engine/oil-level", 7);
+        if (getprop("/controls/engines/active-engine") == 1)
+            setprop("/engines/active-engine/oil-level", 8);
+    }
 });
 
 # ========== carburetor icing ======================

--- a/Systems/bushkit.xml
+++ b/Systems/bushkit.xml
@@ -59,6 +59,7 @@ Extra weight and drag due to bush wheels, floats and 180 hp engine
         </switch>
 
         <switch name="extra-weight-180hp">
+        <!-- Basic Empty Weight difference. 160 hp: 1500 lbs, 180 hp: 1642 lbs -->
             <default value="0"/>
             <test logic="AND" value="142">
                 /controls/engines/active-engine EQ 1

--- a/Systems/bushkit.xml
+++ b/Systems/bushkit.xml
@@ -60,15 +60,7 @@ Extra weight and drag due to bush wheels, floats and 180 hp engine
 
         <switch name="extra-weight-180hp">
             <default value="0"/>
-            <!--
-                The weights given by the POH include full oil level. The difference without oil can be calculated as follows:
-                160hp with oil (POH value): 1500 lbs
-                160hp without oil (7 quarts = 12 lbs): 1488 lbs
-                180hp with oil (POH value): 1642 lbs
-                180hp without oil (8 quarts = 14 lbs): 1628 lbs
-                difference without oil: 140 lbs
-            -->
-            <test logic="AND" value="140">
+            <test logic="AND" value="142">
                 /controls/engines/active-engine EQ 1
             </test>
             <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[15]</output>

--- a/Systems/c172p-engine.xml
+++ b/Systems/c172p-engine.xml
@@ -29,7 +29,7 @@
         <fcs_function name="consumed-oil-weight">
             <function>
                 <product>
-                    <property>/engines/active-engine/oil-consumed</property>
+                    <property>/engines/active-engine/oil-lacking</property>
                     <value>1.7686</value>
                     <value>-1</value>
                 </product>

--- a/Systems/c172p-engine.xml
+++ b/Systems/c172p-engine.xml
@@ -26,11 +26,12 @@
 
     <channel name="oil">
     
-        <fcs_function name="extra-weight-oil">
+        <fcs_function name="consumed-oil-weight">
             <function>
                 <product>
-                    <property>/engines/active-engine/oil-level</property>
+                    <property>/engines/active-engine/oil-consumed</property>
                     <value>1.7686</value>
+                    <value>-1</value>
                 </product>
             </function>
             <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[16]</output>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -630,6 +630,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <kill-engine type="bool">false</kill-engine>
             <oil-level type="double">7.0</oil-level>
             <oil-consumed type="double">0.0</oil-consumed>
+            <oil-lacking type="double">0.0</oil-lacking>
             <oil_consumption_allowed type="bool">false</oil_consumption_allowed>
             <carb_ice type="double">0.0</carb_ice>
             <carb_icing_rate type="double">0.0</carb_icing_rate>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -629,6 +629,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <crash-engine type="bool">false</crash-engine>
             <kill-engine type="bool">false</kill-engine>
             <oil-level type="double">7.0</oil-level>
+            <oil-consumed type="double">0.0</oil-consumed>
             <oil_consumption_allowed type="bool">false</oil_consumption_allowed>
             <carb_ice type="double">0.0</carb_ice>
             <carb_icing_rate type="double">0.0</carb_icing_rate>

--- a/c172p.xml
+++ b/c172p.xml
@@ -9,11 +9,10 @@
         <author> Unknown </author>
         <filecreationdate> 2002-01-01 </filecreationdate>
         <version> $Id: c172p.xml,v 1.40 June 2015 $ </version>
-        <!-- experimental stall and spin, up to flat spin March 2014 -->
+        <!-- experimental stall and spin, up to flat spin March 2014, Dany93 (Daniel Dubreuil) -->
         <!-- Source: http://forum.flightgear.org/viewtopic.php?f=25&t=21664&start=45 -->
         <!-- this file with comments for stall and spin to help -->
-        <!-- further modifications for c172p-detailed 2015 -->
-        <!-- FOR TESTS, Two-engine and Propeller choice, dany june 2015-->
+        <!-- further modifications for c172p-detailed 2015 - 2016 -->
         <description> Cessna C-172 </description>
     </fileheader>
 
@@ -49,12 +48,7 @@
         <ixy unit="SLUG*FT2"> -0 </ixy>
         <ixz unit="SLUG*FT2"> -0 </ixz>
         <iyz unit="SLUG*FT2"> -0 </iyz>
-        <!-- 
-            according to the POH, the empty weight is 1500 lbs, but that value includes 7 quarts
-            of oil (max oil for the 160hp engine). Given that 7 quarts of oil weights 12 lbs and
-            are handled separately by the oil system, the true empty weight becomes 1488 lbs 
-        -->
-        <emptywt unit="LBS"> 1488 </emptywt>
+         <emptywt unit="LBS"> 1500 </emptywt>
         <location name="CG" unit="IN">
             <x> 41 </x>
             <y> 0 </y>
@@ -203,13 +197,13 @@
             </location>
         </pointmass>
         
-        <!-- Extra weight due to oil quantity -->
-        <pointmass name="extra weight oil">
+        <!-- Loss of weight due to consumed oil -->
+        <pointmass name="consumed oil weight">
             <weight unit="LBS"> 0 </weight>
             <location name="POINTMASS" unit="IN">
-                <x> -0.886 </x>
-                <y> 0.316 </y>
-                <z> 0.082 </z>
+                <x> -19.7 </x>
+                <y> 0 </y>
+                <z> 26.6 </z>
             </location>
         </pointmass>
     </mass_balance>
@@ -1352,7 +1346,6 @@
                               0.0000	0.0000
                               0.3490	-0.0322
                         </tableData>
-                        <value>0.25</value>
                     </table>
                     <!--
                           stall and spin (1): 

--- a/c172p.xml
+++ b/c172p.xml
@@ -48,7 +48,7 @@
         <ixy unit="SLUG*FT2"> -0 </ixy>
         <ixz unit="SLUG*FT2"> -0 </ixz>
         <iyz unit="SLUG*FT2"> -0 </iyz>
-         <emptywt unit="LBS"> 1500 </emptywt>
+        <emptywt unit="LBS"> 1500 </emptywt>
         <location name="CG" unit="IN">
             <x> 41 </x>
             <y> 0 </y>
@@ -183,11 +183,8 @@
             </location>
         </pointmass>
 
-        <!-- Extra weight due to 180 hp engine, pointmass [15]; managed by Systems/bushkit.xml
-            x location for empty CG at 38.1", cf. 552SP POH p.6-12, Weight and moment tabulation: 1642 lbs, 62600 lb-ins
-            Note that, similarly to the 160hp, the weight above includes 8 quarts of oil (14 lbs), and so the total value
-            without oil is 1628 lbs 
-        -->
+        <!-- Extra weight, Basic empty, for the aircraft with 180 hp engine, pointmass [15]; managed by Systems/bushkit.xml -->
+        <!-- x location for empty CG at 38.1", cf. 552SP POH p.6-12, Weight and moment tabulation: 1642 lbs, 62600 lb-ins -->
         <pointmass name="extra weight 180hp">
             <weight unit="LBS"> 0 </weight>
             <location name="POINTMASS" unit="IN">
@@ -197,7 +194,7 @@
             </location>
         </pointmass>
         
-        <!-- Loss of weight due to consumed oil -->
+        <!-- Loss of weight due to consumed oil, pointmass [16] -->
         <pointmass name="consumed oil weight">
             <weight unit="LBS"> 0 </weight>
             <location name="POINTMASS" unit="IN">

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -125,9 +125,31 @@
                 <property>/engines/active-engine/oil_consumption_allowed</property>
                 <live>true</live>
                 <binding>
+                    <condition>
+                        <equals>
+                            <property>/controls/engines/active-engine</property>
+                            <value type="int">0</value>
+                        </equals>
+                    </condition>
                     <command>property-assign</command>
                     <property>/engines/active-engine/oil-level</property>
                     <value>7.0</value>
+                </binding>
+                <binding>
+                    <condition>
+                        <equals>
+                            <property>/controls/engines/active-engine</property>
+                            <value type="int">1</value>
+                        </equals>
+                    </condition>
+                    <command>property-assign</command>
+                    <property>/engines/active-engine/oil-level</property>
+                    <value>8.0</value>
+                </binding>
+                <binding>
+                    <command>property-assign</command>
+                    <property>/engines/active-engine/oil-consumed</property>
+                    <value>0.0</value>
                 </binding>
                 <binding>
                     <command>dialog-apply</command>
@@ -139,11 +161,6 @@
                 <label>Allow carburetor icing</label>
                 <property>/engines/active-engine/carb_icing_allowed</property>
                 <live>true</live>
-                <binding>
-                    <command>property-assign</command>
-                    <property>/engines/active-engine/oil-level</property>
-                    <value>7.0</value>
-                </binding>
                 <binding>
                     <command>dialog-apply</command>
                 </binding>
@@ -489,6 +506,11 @@
                         <property>/engines/active-engine/oil-level</property>
                         <value>7.0</value>
                     </binding>
+                    <binding>
+                        <command>property-assign</command>
+                        <property>/engines/active-engine/oil-consumed</property>
+                        <value>0.0</value>
+                    </binding>
                 </radio>
 
                 <radio>
@@ -525,6 +547,11 @@
                         <command>property-assign</command>
                         <property>/engines/active-engine/oil-level</property>
                         <value>8.0</value>
+                    </binding>
+                    <binding>
+                        <command>property-assign</command>
+                        <property>/engines/active-engine/oil-consumed</property>
+                        <value>0.0</value>
                     </binding>
                 </radio>
             </group>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -125,28 +125,6 @@
                 <property>/engines/active-engine/oil_consumption_allowed</property>
                 <live>true</live>
                 <binding>
-                    <condition>
-                        <equals>
-                            <property>/controls/engines/active-engine</property>
-                            <value type="int">0</value>
-                        </equals>
-                    </condition>
-                    <command>property-assign</command>
-                    <property>/engines/active-engine/oil-level</property>
-                    <value>7.0</value>
-                </binding>
-                <binding>
-                    <condition>
-                        <equals>
-                            <property>/controls/engines/active-engine</property>
-                            <value type="int">1</value>
-                        </equals>
-                    </condition>
-                    <command>property-assign</command>
-                    <property>/engines/active-engine/oil-level</property>
-                    <value>8.0</value>
-                </binding>
-                <binding>
                     <command>property-assign</command>
                     <property>/engines/active-engine/oil-consumed</property>
                     <value>0.0</value>


### PR DESCRIPTION
See https://github.com/Juanvvc/c172p-detailed/issues/851#issue-186835178

- Changes the way aircraft weight and CG are calculated, by _subtracting_ the _consumed_ oil from the POH Basic Empty Weight. Much more simple to understand and easier to calculate and implement.
- Fixes some bugs about the oil content (7 or 8 quarts) vs the 160 hp / 180 hp engine.