### PR TITLE
if Oil management disabled, set oil-lacking = 0

### DIFF
--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -89,13 +89,17 @@ var primerTimer = maketimer(5, func {
 # ========== oil consumption ======================
 
 var oil_consumption = maketimer(1.0, func {
+
+    var oil_level = getprop("/engines/active-engine/oil-level");
+    var oil_consumed = getprop("/engines/active-engine/oil-consumed");
+    if (getprop("/controls/engines/active-engine") == 0)
+        var oil_full = 7;
+    if (getprop("/controls/engines/active-engine") == 1)
+        var oil_full = 8;
+    var oil_lacking = oil_full - oil_level;
+    setprop("/engines/active-engine/oil-lacking", oil_lacking);
+    
     if (getprop("/engines/active-engine/oil_consumption_allowed")) {
-        var oil_level = getprop("/engines/active-engine/oil-level");
-        var oil_consumed = getprop("/engines/active-engine/oil-consumed");
-        if (getprop("/controls/engines/active-engine") == 0)
-            var oil_full = 7;
-        if (getprop("/controls/engines/active-engine") == 1)
-            var oil_full = 8;
     
         var rpm = getprop("/engines/active-engine/rpm");
     
@@ -117,9 +121,6 @@ var oil_consumption = maketimer(1.0, func {
             setprop("/engines/active-engine/oil-consumed", oil_consumed);
         }
 
-        var oil_lacking = oil_full - oil_level;
-        setprop("/engines/active-engine/oil-lacking", oil_lacking);
-    
         # If oil gets low (< 5.0), pressure should drop and temperature should rise
         var oil_level_limited = std.min(oil_level, 5.0);
     
@@ -139,7 +140,6 @@ var oil_consumption = maketimer(1.0, func {
             setprop("/engines/active-engine/oil-level", 7);
         if (getprop("/controls/engines/active-engine") == 1)
             setprop("/engines/active-engine/oil-level", 8);
-        setprop("/engines/active-engine/oil-lacking", 0);
     }
 });
 

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -91,7 +91,6 @@ var primerTimer = maketimer(5, func {
 var oil_consumption = maketimer(1.0, func {
 
     var oil_level = getprop("/engines/active-engine/oil-level");
-    var oil_consumed = getprop("/engines/active-engine/oil-consumed");
     if (getprop("/controls/engines/active-engine") == 0)
         var oil_full = 7;
     if (getprop("/controls/engines/active-engine") == 1)
@@ -111,15 +110,13 @@ var oil_consumption = maketimer(1.0, func {
         # at cruise RPM
         var consumption_rate = 1.5 / 36000; 
     
-        var low_oil_pressure_factor = 1.0;
-        var low_oil_temperature_factor = 1.0;
-    
         if (getprop("/engines/active-engine/running")) {
-            oil_consumed = oil_consumed + consumption_rate * rpm_factor;     
             oil_level = oil_level - consumption_rate * rpm_factor;
             setprop("/engines/active-engine/oil-level", oil_level);
-            setprop("/engines/active-engine/oil-consumed", oil_consumed);
         }
+
+        var low_oil_pressure_factor = 1.0;
+        var low_oil_temperature_factor = 1.0;
 
         # If oil gets low (< 5.0), pressure should drop and temperature should rise
         var oil_level_limited = std.min(oil_level, 5.0);

--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -139,6 +139,7 @@ var oil_consumption = maketimer(1.0, func {
             setprop("/engines/active-engine/oil-level", 7);
         if (getprop("/controls/engines/active-engine") == 1)
             setprop("/engines/active-engine/oil-level", 8);
+        setprop("/engines/active-engine/oil-lacking", 0);
     }
 });
 

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -629,7 +629,6 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <crash-engine type="bool">false</crash-engine>
             <kill-engine type="bool">false</kill-engine>
             <oil-level type="double">7.0</oil-level>
-            <oil-consumed type="double">0.0</oil-consumed>
             <oil-lacking type="double">0.0</oil-lacking>
             <oil_consumption_allowed type="bool">false</oil_consumption_allowed>
             <carb_ice type="double">0.0</carb_ice>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -125,11 +125,6 @@
                 <property>/engines/active-engine/oil_consumption_allowed</property>
                 <live>true</live>
                 <binding>
-                    <command>property-assign</command>
-                    <property>/engines/active-engine/oil-consumed</property>
-                    <value>0.0</value>
-                </binding>
-                <binding>
                     <command>dialog-apply</command>
                 </binding>
             </checkbox>
@@ -484,11 +479,6 @@
                         <property>/engines/active-engine/oil-level</property>
                         <value>7.0</value>
                     </binding>
-                    <binding>
-                        <command>property-assign</command>
-                        <property>/engines/active-engine/oil-consumed</property>
-                        <value>0.0</value>
-                    </binding>
                 </radio>
 
                 <radio>
@@ -525,11 +515,6 @@
                         <command>property-assign</command>
                         <property>/engines/active-engine/oil-level</property>
                         <value>8.0</value>
-                    </binding>
-                    <binding>
-                        <command>property-assign</command>
-                        <property>/engines/active-engine/oil-consumed</property>
-                        <value>0.0</value>
                     </binding>
                 </radio>
             </group>


### PR DESCRIPTION
Correction: set "oil-lacking" = 0 when "Allow oil management" is **disabled** (unchecked).
(only "oil-consumed" was reset to 0 and "full level" reset to 7 or 8)