### PR TITLE
160 hp aircraft: empty weight correction, 1467 lbs in accordance with POH

### DIFF
--- a/Systems/bushkit.xml
+++ b/Systems/bushkit.xml
@@ -2,8 +2,8 @@
 
 <!--
 ***********************************************************************************
-c172p-detailed, May 2015 
-Extra weight and drag due to bush wheels, floats and 180 hp engine
+c172p-detailed, May 2015... Nov. 2016 
+Extra weight and drag due to bush wheels, floats and aircraft with 180 hp engine
 ***********************************************************************************
  -->
 
@@ -59,9 +59,9 @@ Extra weight and drag due to bush wheels, floats and 180 hp engine
         </switch>
 
         <switch name="extra-weight-180hp">
-        <!-- Basic Empty Weight difference. 160 hp: 1500 lbs, 180 hp: 1642 lbs -->
+        <!-- Aircraft **Basic Empty Weight** difference. 160 hp: 1467 lbs, 180 hp: 1642 lbs -->
             <default value="0"/>
-            <test logic="AND" value="142">
+            <test logic="AND" value="175">
                 /controls/engines/active-engine EQ 1
             </test>
             <output>/fdm/jsbsim/inertia/pointmass-weight-lbs[15]</output>

--- a/c172p.xml
+++ b/c172p.xml
@@ -41,6 +41,10 @@
         </location>
     </metrics>
 
+        <!-- 
+            Cessna 172P Skyhawk 1982 (160hp) POH p.6-10, Weight and Moment:
+            **Basic Empty** (= with full oil) 1467 lbs, 57300 lb-ins. Gives CG at 39.1 ins.
+        -->
     <mass_balance>
         <ixx unit="SLUG*FT2"> 948 </ixx>
         <iyy unit="SLUG*FT2"> 1346 </iyy>
@@ -48,9 +52,9 @@
         <ixy unit="SLUG*FT2"> -0 </ixy>
         <ixz unit="SLUG*FT2"> -0 </ixz>
         <iyz unit="SLUG*FT2"> -0 </iyz>
-        <emptywt unit="LBS"> 1500 </emptywt>
+        <emptywt unit="LBS"> 1467 </emptywt>
         <location name="CG" unit="IN">
-            <x> 41 </x>
+            <x> 39.1 </x>
             <y> 0 </y>
             <z> 36.5 </z>
         </location>
@@ -183,19 +187,19 @@
             </location>
         </pointmass>
 
-        <!-- Extra weight, Basic empty, for the aircraft with 180 hp engine, pointmass [15]; managed by Systems/bushkit.xml -->
-        <!-- x location for empty CG at 38.1", cf. 552SP POH p.6-12, Weight and moment tabulation: 1642 lbs, 62600 lb-ins -->
+        <!-- Extra weight for the aircraft with 180 hp engine, **Basic empty** (= with full oil), pointmass [15]; managed by Systems/bushkit.xml -->
+        <!-- for empty aircraft CG at x = 38.1 ins, cf. 172S - N552SP POH (1998) p.6-12, Weight and moment tabulation: 1642 lbs, 62600 lb-ins -->
         <pointmass name="extra weight 180hp">
             <weight unit="LBS"> 0 </weight>
             <location name="POINTMASS" unit="IN">
-                <x> 7.75 </x>
+                <x> 30.3 </x>
                 <y>  0 </y>
                 <z> 26.6 </z>
             </location>
         </pointmass>
         
-        <!-- Loss of weight due to consumed oil, pointmass [16] -->
-        <pointmass name="consumed oil weight">
+        <!-- Loss of weight due to lacking oil, pointmass [16]. engine.nas, c172p-engine.xml -->
+        <pointmass name="lacking oil weight">
             <weight unit="LBS"> 0 </weight>
             <location name="POINTMASS" unit="IN">
                 <x> -19.7 </x>


### PR DESCRIPTION
The initial value (already in the jan. 2012 FG version) was 1500 lbs in the FDM.
According to the **Cessna 172P Skyhawk 1982 (160hp) POH p.6-10 (112/357 pdf)** the basic empty weight (= with full oil) is **1467 lbs**.
The empty center of gravity has been recalculated, to be in accordance with this same POH (57300 lbs.ins, which gives **39.1 "**).
Probably not very noticeable on the behaviour but at least for the consistency...

The 180 hp empty weight and CG are unchanged.
The extra weight added at 160 hp to obtain the 180 hp version has been also recalculated for that.