### PR TITLE
Fixing issue #849 and correcting the securing properties in securing.xml

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -7207,10 +7207,15 @@
             <repeatable>false</repeatable>
             <binding>
                 <condition>
-                    <property>/sim/model/c172p/securing/pitot-cover-removable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <and>
+                            <property>/sim/model/c172p/securing/pitot-cover-removable</property>
+                            <not>
+                                <property>/sim/current-view/internal</property>
+                            </not>
+                        </and>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/pitot-cover"/>
@@ -7220,10 +7225,15 @@
         <hovered>
             <binding>
                 <condition>
-                    <property>/sim/model/c172p/securing/pitot-cover-removable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <and>
+                            <property>/sim/model/c172p/securing/pitot-cover-removable</property>
+                            <not>
+                                <property>/sim/current-view/internal</property>
+                            </not>
+                        </and>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>remove-pitot-tube-cap</tooltip-id>
@@ -7239,10 +7249,15 @@
             <repeatable>false</repeatable>
             <binding>
                 <condition>
-                    <property>/sim/model/c172p/securing/pitot-cover-addable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <and>
+                            <property>/sim/model/c172p/securing/pitot-cover-addable</property>
+                            <not>
+                                <property>/sim/current-view/internal</property>
+                            </not>
+                        </and>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/pitot-cover"/>
@@ -7257,10 +7272,15 @@
         <hovered>
             <binding>
                 <condition>
-                    <property>/sim/model/c172p/securing/pitot-cover-addable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <and>
+                            <property>/sim/model/c172p/securing/pitot-cover-addable</property>
+                            <not>
+                                <property>/sim/current-view/internal</property>
+                            </not>
+                        </and>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>put-pitot-tube-cap</tooltip-id>
@@ -7367,9 +7387,12 @@
             <repeatable>false</repeatable>
             <binding>
                 <condition>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <not>
+                            <property>/sim/current-view/internal</property>
+                        </not>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>property-assign</command>
                 <property>/sim/model/c172p/securing/chock</property>
@@ -7380,9 +7403,12 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/chock</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <not>
+                            <property>/sim/current-view/internal</property>
+                        </not>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>remove-wheel-chock</tooltip-id>
@@ -7399,10 +7425,15 @@
             <repeatable>false</repeatable>
             <binding>
                 <condition>
-                    <property>/sim/model/c172p/securing/chock-addable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <and>
+                            <property>/sim/model/c172p/securing/chock-addable</property>
+                            <not>
+                                <property>/sim/current-view/internal</property>
+                            </not>
+                        </and>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>property-assign</command>
                 <property>sim/model/c172p/securing/chock</property>
@@ -7413,9 +7444,15 @@
             <binding>
                 <condition>
                     <property>/sim/model/c172p/securing/chock-addable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <and>
+                            <property>/sim/model/c172p/securing/chock-addable</property>
+                            <not>
+                                <property>/sim/current-view/internal</property>
+                            </not>
+                        </and>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>secure-with-wheel-chock</tooltip-id>
@@ -7451,9 +7488,12 @@
             <repeatable>false</repeatable>
             <binding>
                 <condition>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <not>
+                            <property>/sim/current-view/internal</property>
+                        </not>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/tiedowns/left/visible"/>
@@ -7464,9 +7504,12 @@
             <binding>
                 <condition>
                     <property alias="/params/securing/tiedowns/left/visible"/>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <not>
+                            <property>/sim/current-view/internal</property>
+                        </not>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>remove-left-tiedowns</tooltip-id>
@@ -7478,10 +7521,18 @@
         <type>select</type>
         <object-name>TiedownHotSpotLeft</object-name>
         <condition>
-            <property>/sim/model/c172p/securing/tiedownL-addable</property>
-            <not>
-                <property>/sim/current-view/internal</property>
-            </not>
+            <or>
+                <and>
+                    <property>/sim/model/c172p/securing/tiedownL-addable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
+                </and>
+                <and>
+                    <property>/sim/model/c172p/securing/tiedownL-addable</property>
+                    <property>/nasal/tutorial/loaded</property>
+                </and>
+            </or>
         </condition>
     </animation>
     <animation>
@@ -7492,10 +7543,15 @@
             <repeatable>false</repeatable>
             <binding>
                 <condition>
-                    <property>/sim/model/c172p/securing/tiedownL-addable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <and>
+                            <property>/sim/model/c172p/securing/tiedownL-addable</property>
+                            <not>
+                                <property>/sim/current-view/internal</property>
+                            </not>
+                        </and>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/tiedowns/left/visible"/>
@@ -7505,10 +7561,15 @@
         <hovered>
             <binding>
                 <condition>
-                    <property>/sim/model/c172p/securing/tiedownL-addable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <and>
+                            <property>/sim/model/c172p/securing/tiedownL-addable</property>
+                            <not>
+                                <property>/sim/current-view/internal</property>
+                            </not>
+                        </and>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>secure-with-left-tiedowns</tooltip-id>
@@ -7544,9 +7605,12 @@
             <repeatable>false</repeatable>
             <binding>
                 <condition>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <not>
+                            <property>/sim/current-view/internal</property>
+                        </not>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/tiedowns/right/visible"/>
@@ -7557,9 +7621,12 @@
             <binding>
                 <condition>
                     <property alias="/params/securing/tiedowns/right/visible"/>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <not>
+                            <property>/sim/current-view/internal</property>
+                        </not>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>remove-right-tiedowns</tooltip-id>
@@ -7571,10 +7638,18 @@
         <type>select</type>
         <object-name>TiedownHotSpotRight</object-name>
         <condition>
-            <property>/sim/model/c172p/securing/tiedownR-addable</property>
-            <not>
-                <property>/sim/current-view/internal</property>
-            </not>
+            <or>
+                <and>
+                    <property>/sim/model/c172p/securing/tiedownR-addable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
+                </and>
+                <and>
+                    <property>/sim/model/c172p/securing/tiedownR-addable</property>
+                    <property>/nasal/tutorial/loaded</property>
+                </and>
+            </or>
         </condition>
     </animation>
     <animation>
@@ -7585,10 +7660,15 @@
             <repeatable>false</repeatable>
             <binding>
                 <condition>
-                    <property>/sim/model/c172p/securing/tiedownR-addable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <and>
+                            <property>/sim/model/c172p/securing/tiedownR-addable</property>
+                            <not>
+                                <property>/sim/current-view/internal</property>
+                            </not>
+                        </and>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/tiedowns/right/visible"/>
@@ -7598,10 +7678,15 @@
         <hovered>
             <binding>
                 <condition>
-                    <property>/sim/model/c172p/securing/tiedownR-addable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <and>
+                            <property>/sim/model/c172p/securing/tiedownR-addable</property>
+                            <not>
+                                <property>/sim/current-view/internal</property>
+                            </not>
+                        </and>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>secure-with-right-tiedowns</tooltip-id>
@@ -7637,9 +7722,12 @@
             <repeatable>false</repeatable>
             <binding>
                 <condition>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <not>
+                            <property>/sim/current-view/internal</property>
+                        </not>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/tiedowns/tail/visible"/>
@@ -7650,9 +7738,12 @@
             <binding>
                 <condition>
                     <property alias="/params/securing/tiedowns/tail/visible"/>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <not>
+                            <property>/sim/current-view/internal</property>
+                        </not>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>remove-tail-tiedowns</tooltip-id>
@@ -7664,10 +7755,18 @@
         <type>select</type>
         <object-name>TiedownHotSpotTail</object-name>
         <condition>
-            <property>/sim/model/c172p/securing/tiedownT-addable</property>
-            <not>
-                <property>/sim/current-view/internal</property>
-            </not>
+            <or>
+                <and>
+                    <property>/sim/model/c172p/securing/tiedownT-addable</property>
+                    <not>
+                        <property>/sim/current-view/internal</property>
+                    </not>
+                </and>
+                <and>
+                    <property>/sim/model/c172p/securing/tiedownT-addable</property>
+                    <property>/nasal/tutorial/loaded</property>
+                </and>
+            </or>
         </condition>
     </animation>
     <animation>
@@ -7678,10 +7777,15 @@
             <repeatable>false</repeatable>
             <binding>
                 <condition>
-                    <property>/sim/model/c172p/securing/tiedownT-addable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <and>
+                            <property>/sim/model/c172p/securing/tiedownT-addable</property>
+                            <not>
+                                <property>/sim/current-view/internal</property>
+                            </not>
+                        </and>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>property-assign</command>
                 <property alias="/params/securing/tiedowns/tail/visible"/>
@@ -7691,10 +7795,15 @@
         <hovered>
             <binding>
                 <condition>
-                    <property>/sim/model/c172p/securing/tiedownT-addable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
+                    <or>
+                        <and>
+                            <property>/sim/model/c172p/securing/tiedownT-addable</property>
+                            <not>
+                                <property>/sim/current-view/internal</property>
+                            </not>
+                        </and>
+                        <property>/nasal/tutorial/loaded</property>
+                    </or>
                 </condition>
                 <command>set-tooltip</command>
                 <tooltip-id>secure-with-tail-tiedowns</tooltip-id>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -7521,17 +7521,10 @@
         <type>select</type>
         <object-name>TiedownHotSpotLeft</object-name>
         <condition>
+            <property>/sim/model/c172p/securing/tiedownL-addable</property>
             <or>
-                <and>
-                    <property>/sim/model/c172p/securing/tiedownL-addable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
-                </and>
-                <and>
-                    <property>/sim/model/c172p/securing/tiedownL-addable</property>
-                    <property>/nasal/tutorial/loaded</property>
-                </and>
+                <property>/sim/current-view/internal</property>
+                <property>/nasal/tutorial/loaded</property>
             </or>
         </condition>
     </animation>
@@ -7638,17 +7631,10 @@
         <type>select</type>
         <object-name>TiedownHotSpotRight</object-name>
         <condition>
+            <property>/sim/model/c172p/securing/tiedownR-addable</property>
             <or>
-                <and>
-                    <property>/sim/model/c172p/securing/tiedownR-addable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
-                </and>
-                <and>
-                    <property>/sim/model/c172p/securing/tiedownR-addable</property>
-                    <property>/nasal/tutorial/loaded</property>
-                </and>
+                <property>/sim/current-view/internal</property>
+                <property>/nasal/tutorial/loaded</property>
             </or>
         </condition>
     </animation>
@@ -7755,17 +7741,10 @@
         <type>select</type>
         <object-name>TiedownHotSpotTail</object-name>
         <condition>
+            <property>/sim/model/c172p/securing/tiedownT-addable</property>
             <or>
-                <and>
-                    <property>/sim/model/c172p/securing/tiedownT-addable</property>
-                    <not>
-                        <property>/sim/current-view/internal</property>
-                    </not>
-                </and>
-                <and>
-                    <property>/sim/model/c172p/securing/tiedownT-addable</property>
-                    <property>/nasal/tutorial/loaded</property>
-                </and>
+                <property>/sim/current-view/internal</property>
+                <property>/nasal/tutorial/loaded</property>
             </or>
         </condition>
     </animation>

--- a/Tutorials/preflight.xml
+++ b/Tutorials/preflight.xml
@@ -1130,6 +1130,10 @@ This tutorial will guide you through the Preflight inspection
     </step>
 
     <step>
+        <set>
+            <property>/nasal/tutorial/loaded</property>
+            <value>false</value>
+        </set>
         <message>Perfect, you're finished. The aircraft is in a good condition, and you're ready to start the engine.</message>
         <view>
             <heading-offset-deg>0.0</heading-offset-deg>

--- a/Tutorials/securing.xml
+++ b/Tutorials/securing.xml
@@ -568,13 +568,13 @@ Starting this tutorial with the engine not running will NOT work!
             <message>To protect the Pitot tube, you have to cover it!</message>
             <condition>
                 <not>
-                    <property>sim/model/c172p/pitot-cover</property>
+                    <property>sim/model/c172p/securing/pitot-cover-visible</property>
                 </not>
             </condition>
         </error>
         <exit>
             <condition>
-                <property>sim/model/c172p/pitot-cover</property>
+                <property>sim/model/c172p/securing/pitot-cover-visible</property>
             </condition>
         </exit>
     </step>
@@ -600,13 +600,13 @@ Starting this tutorial with the engine not running will NOT work!
             <message>You have to secure the aircraft with the tiedowns!</message>
             <condition>
                 <not>
-                    <property>sim/model/c172p/tiedownL</property>
+                    <property>sim/model/c172p/securing/tiedownL-visible</property>
                 </not>
             </condition>
         </error>
         <exit>
             <condition>
-                <property>sim/model/c172p/tiedownL</property>
+                <property>sim/model/c172p/securing/tiedownL-visible</property>
             </condition>
         </exit>
     </step>
@@ -632,13 +632,13 @@ Starting this tutorial with the engine not running will NOT work!
             <message>You must place the wheel chocks now!</message>
             <condition>
                 <not>
-                    <property>sim/model/c172p/chock</property>
+                    <property>sim/model/c172p/securing/chock</property>
                 </not>
             </condition>
         </error>
         <exit>
             <condition>
-                <property>sim/model/c172p/chock</property>
+                <property>sim/model/c172p/securing/chock</property>
             </condition>
         </exit>
     </step>
@@ -664,13 +664,13 @@ Starting this tutorial with the engine not running will NOT work!
             <message>You have to secure the aircraft with the tiedowns!</message>
             <condition>
                 <not>
-                    <property>sim/model/c172p/tiedownR</property>
+                    <property>sim/model/c172p/securing/tiedownR-visible</property>
                 </not>
             </condition>
         </error>
         <exit>
             <condition>
-                <property>sim/model/c172p/tiedownR</property>
+                <property>sim/model/c172p/securing/tiedownR-visible</property>
             </condition>
         </exit>
     </step>
@@ -696,18 +696,22 @@ Starting this tutorial with the engine not running will NOT work!
             <message>You have to secure the aircraft with the tiedowns!</message>
             <condition>
                 <not>
-                    <property>sim/model/c172p/tiedownT</property>
+                    <property>sim/model/c172p/securing/tiedownT-visible</property>
                 </not>
             </condition>
         </error>
         <exit>
             <condition>
-                <property>sim/model/c172p/tiedownT</property>
+                <property>sim/model/c172p/securing/tiedownT-visible</property>
             </condition>
         </exit>
     </step>
 
     <step>
+        <set>
+            <property>/nasal/tutorial/loaded</property>
+            <value>false</value>
+        </set>
         <message>Congratulations! You finally made it! Now let's go and have a beer...</message>
         <view>
             <heading-offset-deg>313.2</heading-offset-deg>


### PR DESCRIPTION
Fix #849 

The properties for pitot cover, tiedowns and chocks in the securing tutorial were outdated. I corrected them :smirk: 