### PR TITLE
implementing control surfaces check

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -8322,5 +8322,107 @@
             <heading-deg>0.0</heading-deg>
         </offsets>
     </model>
+    
+    <!-- Preflight surface checks -->
+    <!-- elevator surface check -->
+    <animation>
+        <type>pick</type>
+        <object-name>elevatorleft</object-name>
+        <object-name>elevatorright</object-name>
+        <action>
+            <button>0</button>
+            <repeatable>false</repeatable>
+            <binding>
+                <condition>
+                    <and>
+                        <not>            
+                            <property>/engines/active-engine/running</property>
+                        </not>
+                        <less-than>
+                            <property>velocities/groundspeed-kt</property>
+                            <value>1.0</value>
+                        </less-than>
+                    </and>
+                </condition>
+                <command>nasal</command>
+                <script>c172p.control_surface_check_elevator();</script>
+            </binding>
+        </action>
+    </animation>
+    
+    <!-- left aileron surface check -->
+    <animation>
+        <type>pick</type>
+        <object-name>leftaileron</object-name>
+        <action>
+            <button>0</button>
+            <repeatable>false</repeatable>
+            <binding>
+                <condition>
+                    <and>
+                        <not>            
+                            <property>/engines/active-engine/running</property>
+                        </not>
+                        <less-than>
+                            <property>velocities/groundspeed-kt</property>
+                            <value>1.0</value>
+                        </less-than>
+                    </and>
+                </condition>
+                <command>nasal</command>
+                <script>c172p.control_surface_check_left_aileron();</script>
+            </binding>
+        </action>
+    </animation>
+    
+    <!-- right aileron surface check -->
+    <animation>
+        <type>pick</type>
+        <object-name>rightaileron</object-name>
+        <action>
+            <button>0</button>
+            <repeatable>false</repeatable>
+            <binding>
+                <condition>
+                    <and>
+                        <not>            
+                            <property>/engines/active-engine/running</property>
+                        </not>
+                        <less-than>
+                            <property>velocities/groundspeed-kt</property>
+                            <value>1.0</value>
+                        </less-than>
+                    </and>
+                </condition>
+                <command>nasal</command>
+                <script>c172p.control_surface_check_right_aileron();</script>
+            </binding>
+        </action>
+    </animation>
+    
+    <!-- rudder surface check -->
+    <animation>
+        <type>pick</type>
+        <object-name>rudder</object-name>
+        <action>
+            <button>0</button>
+            <repeatable>false</repeatable>
+            <binding>
+                <condition>
+                    <and>
+                        <not>            
+                            <property>/engines/active-engine/running</property>
+                        </not>
+                        <less-than>
+                            <property>velocities/groundspeed-kt</property>
+                            <value>1.0</value>
+                        </less-than>
+                    </and>
+                </condition>
+                <command>nasal</command>
+                <script>c172p.control_surface_check_rudder();</script>
+            </binding>
+        </action>
+    </animation>
 
 </PropertyList>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -8342,6 +8342,9 @@
                             <property>velocities/groundspeed-kt</property>
                             <value>1.0</value>
                         </less-than>
+                        <not>
+                            <property>/sim/current-view/internal</property>
+                        </not>
                     </and>
                 </condition>
                 <command>nasal</command>
@@ -8367,6 +8370,9 @@
                             <property>velocities/groundspeed-kt</property>
                             <value>1.0</value>
                         </less-than>
+                        <not>
+                            <property>/sim/current-view/internal</property>
+                        </not>
                     </and>
                 </condition>
                 <command>nasal</command>
@@ -8392,6 +8398,9 @@
                             <property>velocities/groundspeed-kt</property>
                             <value>1.0</value>
                         </less-than>
+                        <not>
+                            <property>/sim/current-view/internal</property>
+                        </not>
                     </and>
                 </condition>
                 <command>nasal</command>
@@ -8417,6 +8426,9 @@
                             <property>velocities/groundspeed-kt</property>
                             <value>1.0</value>
                         </less-than>
+                        <not>
+                            <property>/sim/current-view/internal</property>
+                        </not>
                     </and>
                 </condition>
                 <command>nasal</command>

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -195,17 +195,11 @@ var return_fuel_sample = func(index) {
 ##########################################
 var control_surface_check_left_aileron = func {
     var auto_coordination = getprop("/controls/flight/auto-coordination");
-    setprop("/controls/flight/auto-coordination", "false");
-    interpolate("/controls/flight/aileron", 1.0, 0.3);
-    settimer(func(){
-        interpolate("/controls/flight/aileron", -1.0, 0.6);
-    }, 0.3);
-    settimer(func(){
-        interpolate("/controls/flight/aileron", 0.0, 0.3);
-    }, 0.9);
+    setprop("/controls/flight/auto-coordination", 0);
+    interpolate("/controls/flight/aileron", 1.0, 0.5, -1.0, 1.0, 0.0, 0.5);
     settimer(func(){
         setprop("/controls/flight/auto-coordination", auto_coordination);
-    }, 1.2);
+    }, 2.0);
 };
 
 ##########################################
@@ -213,43 +207,25 @@ var control_surface_check_left_aileron = func {
 ##########################################
 var control_surface_check_right_aileron = func {
     var auto_coordination = getprop("/controls/flight/auto-coordination");
-    setprop("/controls/flight/auto-coordination", "false");
-    interpolate("/controls/flight/aileron", -1.0, 0.3);
-    settimer(func(){
-        interpolate("/controls/flight/aileron", 1.0, 0.6);
-    }, 0.3);
-    settimer(func(){
-        interpolate("/controls/flight/aileron", 0.0, 0.3);
-    }, 0.9);
+    setprop("/controls/flight/auto-coordination", 0);
+    interpolate("/controls/flight/aileron", -1.0, 0.5, 1.0, 1.0, 0.0, 0.5);
     settimer(func(){
         setprop("/controls/flight/auto-coordination", auto_coordination);
-    }, 1.2);
+    }, 2.0);
 };
 
 ##########################################
 # Preflight control surface check: elevator
 ##########################################
 var control_surface_check_elevator = func {
-    interpolate("/controls/flight/elevator", 0.7, 0.5);
-    settimer(func(){
-        interpolate("/controls/flight/elevator", -0.7, 1.0);
-    }, 0.5);
-    settimer(func(){
-        interpolate("/controls/flight/elevator", 0.0, 0.5);
-    }, 1.5);
+    interpolate("/controls/flight/elevator", 1.0, 0.8, -1.0, 1.6, 0.0, 0.8);
 };
 
 ##########################################
 # Preflight control surface check: rudder
 ##########################################
 var control_surface_check_rudder = func {
-    interpolate("/controls/flight/rudder", -0.7, 0.5);
-    settimer(func(){
-        interpolate("/controls/flight/rudder", 0.7, 1.0);
-    }, 0.5);
-    settimer(func(){
-        interpolate("/controls/flight/rudder", 0.0, 0.5);
-    }, 1.5);
+    interpolate("/controls/flight/rudder", -1.0, 0.8, 1.0, 1.6, 0.0, 0.8);
 };
 
 ##########################################

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -191,6 +191,68 @@ var return_fuel_sample = func(index) {
 };
 
 ##########################################
+# Preflight control surface check: left aileron
+##########################################
+var control_surface_check_left_aileron = func {
+    var auto_coordination = getprop("/controls/flight/auto-coordination");
+    setprop("/controls/flight/auto-coordination", "false");
+    interpolate("/controls/flight/aileron", 1.0, 0.3);
+    settimer(func(){
+        interpolate("/controls/flight/aileron", -1.0, 0.6);
+    }, 0.3);
+    settimer(func(){
+        interpolate("/controls/flight/aileron", 0.0, 0.3);
+    }, 0.9);
+    settimer(func(){
+        setprop("/controls/flight/auto-coordination", auto_coordination);
+    }, 1.2);
+};
+
+##########################################
+# Preflight control surface check: right aileron
+##########################################
+var control_surface_check_right_aileron = func {
+    var auto_coordination = getprop("/controls/flight/auto-coordination");
+    setprop("/controls/flight/auto-coordination", "false");
+    interpolate("/controls/flight/aileron", -1.0, 0.3);
+    settimer(func(){
+        interpolate("/controls/flight/aileron", 1.0, 0.6);
+    }, 0.3);
+    settimer(func(){
+        interpolate("/controls/flight/aileron", 0.0, 0.3);
+    }, 0.9);
+    settimer(func(){
+        setprop("/controls/flight/auto-coordination", auto_coordination);
+    }, 1.2);
+};
+
+##########################################
+# Preflight control surface check: elevator
+##########################################
+var control_surface_check_elevator = func {
+    interpolate("/controls/flight/elevator", 0.7, 0.5);
+    settimer(func(){
+        interpolate("/controls/flight/elevator", -0.7, 1.0);
+    }, 0.5);
+    settimer(func(){
+        interpolate("/controls/flight/elevator", 0.0, 0.5);
+    }, 1.5);
+};
+
+##########################################
+# Preflight control surface check: rudder
+##########################################
+var control_surface_check_rudder = func {
+    interpolate("/controls/flight/rudder", -0.7, 0.5);
+    settimer(func(){
+        interpolate("/controls/flight/rudder", 0.7, 1.0);
+    }, 0.5);
+    settimer(func(){
+        interpolate("/controls/flight/rudder", 0.0, 0.5);
+    }, 1.5);
+};
+
+##########################################
 # Switches Save State
 ##########################################
 var switches_save_state = func {


### PR DESCRIPTION
Closes #861

This PR implements control surfaces check. In the external view or using the walker, simply click on the ailerons, rudder and elevator to move them as if the pilot was testing them. Animation only works if the engine is not running and if the groundspeed is < 1.0 knots (same condition as tie-downs, chocks, etc.). The animations last for only 1-2 seconds and will override any joystick input during that time. The aileron animation temporarily disable auto-coordination if that's on, so that the ailerons move alone without moving the rudder.

Here is a video of this work (note that the video was done before the auto-coordination toggling I mentioned above):

https://youtu.be/ieVGiAv0ntI