### PR TITLE
delay baggage dialog, better sound activation timing

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -2307,8 +2307,12 @@
                         <value>0</value>
                     </equals>
                 </condition>
-                <command>dialog-show</command>
-                <dialog-name>c172p-baggage-weight-dialog</dialog-name>
+                <command>nasal</command>
+                <script>
+                    settimer(func(){
+                        fgcommand("dialog-show", {"dialog-name": "c172p-baggage-weight-dialog"});
+                    }, 2.0);
+                </script>
             </binding>
         </action>
         <hovered>

--- a/c172-sound.xml
+++ b/c172-sound.xml
@@ -1094,7 +1094,7 @@
             <condition>
                 <greater-than>
                     <property>/sim/model/door-positions/baggageDoor/position-norm</property>
-                    <value>0.4</value>
+                    <value>0.0</value>
                 </greater-than>
             </condition>
             <position>


### PR DESCRIPTION
Closes #833

This PR does two things:
- delays the opening of the baggage dialog by 2 seconds when clicking on the baggage door, so that the animation is complete before the dialog is opened
- adjusts the timing of the sound of the baggage door while opening, it was too delayed