### PR TITLE
Fixing issue # 1589

### DIFF
--- a/Models/Interior/Panel/Instruments/garmin196/garmin196.nas
+++ b/Models/Interior/Panel/Instruments/garmin196/garmin196.nas
@@ -224,7 +224,10 @@ var load_parameters = func{
 setlistener("/sim/signals/fdm-initialized",load_parameters);
 
 var save_parameters = func{
-    props.globals.getNode("/instrumentation/garmin196/save").remove();
+
+    var save_branch = props.globals.getNode("/instruments/garmin196");
+    if (save_branch != nil )save_branch.removeChild("save");
+
 
     ##preparation
     if(getprop("/instrumentation/garmin196/antenne-deg")!=nil){


### PR DESCRIPTION
Intermittently in nasal, if you are completely removing a branch node on the property tree and the node you are removing is already not there, nasal will fail silently causing other strange errors. This is if you use prop.remove(). The actual method to use for a branch node is prop.removeChild() which always works regardless of the status of the branch node.

On branch topic/#1589