### PR TITLE
Move AltStaticKnob slider animation to be first inline

### DIFF
--- a/Models/Interior/Panel/c172p-panel/c172p.xml
+++ b/Models/Interior/Panel/c172p-panel/c172p.xml
@@ -6,6 +6,7 @@
     <texture-path>../../../../Models</texture-path>
     <params>
         <controls>
+            <altstaticair>systems/static-selected-source</altstaticair>
             <carb-heat>controls/engines/current-engine/carb-heat</carb-heat>
             <parking-lever>sim/model/c172p/cockpit/parking-lever</parking-lever>
             <carb-heat-animation>sim/model/c172p/cockpit/carb-heat-animation</carb-heat-animation>
@@ -1721,6 +1722,34 @@
         <condition>
             <property>sim/panel-hotspots</property>
         </condition>
+    </animation>
+
+    <!-- Alt static knob -->
+    <animation>
+        <type>slider</type>
+        <object-name>AltStaticAir</object-name>
+        <property>systems/static-selected-source-norm</property>
+        <factor>0.010</factor>
+        <axis>
+            <x>1</x>
+            <y>0</y>
+            <z>0</z>
+        </axis>
+        <action>
+            <binding>
+                <command>property-toggle</command>
+                <property alias="/params/controls/altstaticair"/>
+            </binding>
+        </action>
+        <hovered>
+            <binding>
+                <command>set-tooltip</command>
+                <tooltip-id>alt-static-air-tooltip</tooltip-id>
+                <mapping>on-off</mapping>
+                <label>Alternate static air: %s</label>
+                <property alias="/params/controls/altstaticair"/>
+            </binding>
+        </hovered>
     </animation>
 
     <!-- Primer -->

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -335,7 +335,6 @@
         <!-- TODO To be made MP properties in the future when we get passengers or dual-control -->
         <controls>
             <throttle>controls/engines/current-engine/throttle</throttle>
-            <altstaticair>systems/static-selected-source</altstaticair>
             <mixture>controls/engines/current-engine/mixture</mixture>
             <carb-heat>controls/engines/current-engine/carb-heat</carb-heat>
             <parking-lever>sim/model/c172p/cockpit/parking-lever</parking-lever>
@@ -2776,34 +2775,6 @@
                 <tooltip-id>throttle</tooltip-id>
                 <mapping>percent</mapping>
                 <property alias="/params/controls/throttle"/>
-            </binding>
-        </hovered>
-    </animation>
-
-    <!-- Alt static knob -->
-    <animation>
-        <type>slider</type>
-        <object-name>AltStaticAir</object-name>
-        <property>systems/static-selected-source-norm</property>
-        <factor>0.010</factor>
-        <axis>
-            <x>1</x>
-            <y>0</y>
-            <z>0</z>
-        </axis>
-        <action>
-            <binding>
-                <command>property-toggle</command>
-                <property alias="/params/controls/altstaticair"/>
-            </binding>
-        </action>
-        <hovered>
-            <binding>
-                <command>set-tooltip</command>
-                <tooltip-id>alt-static-air-tooltip</tooltip-id>
-                <mapping>on-off</mapping>
-                <label>Alternate static air: %s</label>
-                <property alias="/params/controls/altstaticair"/>
             </binding>
         </hovered>
     </animation>


### PR DESCRIPTION
Fixes #1593 

@hbeni if your around and have time to test this and merge it. Very simple fix, I just moves the AltStaticKnob slider animation to be before the material animation that was triggering the "duplicate animation" warning. If not I'll merge it in a few days.