### PR TITLE
Fix KR87 ADF timer running at 2x speed

### DIFF
--- a/Nasal/kr87.nas
+++ b/Nasal/kr87.nas
@@ -37,14 +37,14 @@ var timer = {
        return me.timeN.getDoubleValue();
     },
 
-    start : func { 
-       me.runningN.setBoolValue( 1 );
-       me.clock.start();
-    },
-
-    stop : func { 
-       me.runningN.setBoolValue( 0 ); 
-       me.clock.stop();
+    start : func {  
+       if (me.clock.isRunning) return;  
+       me.runningN.setBoolValue( 1 );  
+    },  
+  
+    stop : func {  
+       if (!me.clock.isRunning) return;  
+       me.runningN.setBoolValue( 0 );  
     },
 
     reset : func {

--- a/Nasal/kr87.nas
+++ b/Nasal/kr87.nas
@@ -250,6 +250,11 @@ var kr87 = {
 };
 
 
+var adf0_instance = nil;
+
 setlistener("/sim/signals/fdm-initialized", func {
-    kr87.new( "/instrumentation/adf[0]" ).update();
-} );
+    if (adf0_instance == nil) {
+        adf0_instance = kr87.new( "/instrumentation/adf[0]" );
+        adf0_instance.update();
+    }
+});


### PR DESCRIPTION
Fixes #1597

### Description

`timer.start()` and `timer.stop()` in `Nasal/kr87.nas` explicitly called `me.clock.start()` and `me.clock.stop()` while simultaneously modifying `runningN`. Because `runningN` has a listener that also triggers clock start/stop on change, the timer clock was being armed twice per call.

This caused Elapsed (ET) and Flight (FLT) timers to tick at twice the real-time speed (e.g., 30 minutes accumulated in 15 real minutes).

### Summary of Changes

* Removed redundant direct `me.clock.start()` and `me.clock.stop()` calls in `Nasal/kr87.nas`.
* Timer execution state is now handled solely by the `runningN` listener.
* Restores 1x real-time ticking rate for both Elapsed (ET) and Flight (FLT) ADF timers.